### PR TITLE
Change rails dependency to 6

### DIFF
--- a/graphoid.gemspec
+++ b/graphoid.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   gem.add_dependency 'graphql', '~> 1.8.0'
-  gem.add_dependency 'rails', '~> 5'
+  gem.add_dependency 'rails', '~> 6'
 end


### PR DESCRIPTION
This change is very important, because it will enable **Multiple Queries** on the Graphoid gem when working with **Rails 6**.

![a](https://user-images.githubusercontent.com/7637806/80346103-978b6180-8840-11ea-8514-7fc4341f5fd3.gif)
