### PR TITLE
Change graphql gem dependency from 1.8.0 to 1.12.0

### DIFF
--- a/graphoid.gemspec
+++ b/graphoid.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  gem.add_dependency 'graphql', '~> 1.8.0'
+  gem.add_dependency 'graphql', '~> 1.12.0'
   gem.add_dependency 'rails', '~> 6'
 end


### PR DESCRIPTION
The upgrade of gem is very important, because it will enable [DataLoader](https://graphql-ruby.org/dataloader/overview.html), which is basically aimed to fix N+1 Query Problem when requesting queries with has_many associations. (E.g: Person has_many Books)

References:
1. https://evilmartians.com/chronicles/how-to-graphql-with-ruby-rails-active-record-and-no-n-plus-one
2. https://graphql-ruby.org/dataloader/overview.html