### PR TITLE
Fix inconsistencies with GraphQL version 1.12.0

### DIFF
--- a/graphoid.gemspec
+++ b/graphoid.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  gem.add_dependency 'graphql', '~> 1.12.0'
+  gem.add_dependency 'graphql', '~> 1.8.0'
   gem.add_dependency 'rails', '~> 6'
 end

--- a/lib/graphoid/queries/queries.rb
+++ b/lib/graphoid/queries/queries.rb
@@ -10,6 +10,8 @@ module Graphoid
       grapho = Graphoid.build(model)
       query_type = ::Types::QueryType
 
+      binding.pry
+
       query_type.field name: grapho.name, type: grapho.type, null: true do
         argument :id, GraphQL::Types::ID, required: false
         argument :where, grapho.filter, required: false

--- a/lib/graphoid/queries/queries.rb
+++ b/lib/graphoid/queries/queries.rb
@@ -10,8 +10,6 @@ module Graphoid
       grapho = Graphoid.build(model)
       query_type = ::Types::QueryType
 
-      binding.pry
-
       query_type.field name: grapho.name, type: grapho.type, null: true do
         argument :id, GraphQL::Types::ID, required: false
         argument :where, grapho.filter, required: false
@@ -26,6 +24,7 @@ module Graphoid
       end
 
       query_type.class_eval do
+        binding.pry
         define_method :"#{grapho.name}" do |id: nil, where: nil|
           begin
             return model.find(id) if id
@@ -37,6 +36,7 @@ module Graphoid
       end
 
       query_type.class_eval do
+        binding.pry
         define_method :"#{grapho.plural}" do |where: nil, order: nil, limit: nil, skip: nil|
           begin
             model = Graphoid.driver.eager_load(context.irep_node, model)


### PR DESCRIPTION
Severe problems appeared when upgrading `graphql-ruby` gem to version 1.12.0

* 🚨 **No query can be executed anymore** (just custom ones, like our `evalEquations`)
* 🚨 **No mutation can be executed anymore** (just custom ones)
* 🚨 The automatic generated graphiql documentation became **blank**

## The issue 🪲

<img width="1440" alt="Screen Shot 2022-08-26 at 01 19 41" src="https://user-images.githubusercontent.com/7637806/186821309-ceff691d-ebd4-4495-9b7a-d054633e8dec.png">
