### PR TITLE
Downgrade graphql version

### DIFF
--- a/graphoid.gemspec
+++ b/graphoid.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  gem.add_dependency 'graphql', '~> 1.12.0'
+  gem.add_dependency 'graphql', '~> 1.8.0'
   gem.add_dependency 'rails', '~> 6'
 end

--- a/lib/graphoid/queries/queries.rb
+++ b/lib/graphoid/queries/queries.rb
@@ -37,6 +37,7 @@ module Graphoid
       query_type.class_eval do
         define_method :"#{grapho.plural}" do |where: nil, order: nil, limit: nil, skip: nil|
           begin
+            binding.pry
             model = Graphoid.driver.eager_load(context.irep_node, model)
             result = Processor.execute(model, where.to_h)
             order = Processor.parse_order(model, order.to_h)

--- a/lib/graphoid/queries/queries.rb
+++ b/lib/graphoid/queries/queries.rb
@@ -37,7 +37,6 @@ module Graphoid
       query_type.class_eval do
         define_method :"#{grapho.plural}" do |where: nil, order: nil, limit: nil, skip: nil|
           begin
-            binding.pry
             model = Graphoid.driver.eager_load(context.irep_node, model)
             result = Processor.execute(model, where.to_h)
             order = Processor.parse_order(model, order.to_h)


### PR DESCRIPTION
Severe problems appeared when upgrading `graphql-ruby` gem to version 1.12.0

* 🚨 **No query can be executed anymore** (just custom ones, like our `evalEquations`)
* 🚨 **No mutation can be executed anymore** (just custom ones)
* 🚨 The automatic generated graphiql documentation became **blank**

## The issue 🪲

<img width="1440" alt="Screen Shot 2022-08-26 at 01 19 41" src="https://user-images.githubusercontent.com/7637806/186821309-ceff691d-ebd4-4495-9b7a-d054633e8dec.png">