### PR TITLE
Use #try(:dynamic?) instead of #dynamic?

### DIFF
--- a/lib/graphoid/definitions/sorter.rb
+++ b/lib/graphoid/definitions/sorter.rb
@@ -14,7 +14,7 @@ module Graphoid
 
           Attribute.fields_of(model).each do |field|
             name = Utils.camelize(field.name)
-            next argument(name, Sorter.dynamic_type) if field.dynamic?
+            next argument(name, Sorter.dynamic_type) if field.try(:dynamic?)
             argument(name, Sorter.enum_type)
           end
 


### PR DESCRIPTION
# Description ✍️

We can only call the `dynamic?` method if it exists for the field, otherwise we should not call.

<img width="1177" alt="Screen Shot 2022-12-05 at 14 21 24" src="https://user-images.githubusercontent.com/7637806/205701613-2d1f48fd-bdf6-491b-9bfe-f70f4eb3015d.png">


# Checks ☑️

- [x] Use #try(:dynamic?) instead of #dynamic?
- [ ] Smoke Tests

