### PR TITLE
Create pagination query generators and resolvers hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-
 <img src="https://cl.ly/aeaacddab2e2/graphoid.png" height="150" alt="graphoid"/>
 
 [![CI](https://github.com/oxeanbits/graphoid/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/oxeanbits/graphoid/actions/workflows/build.yml)
 [![Gem Version](https://img.shields.io/badge/gem%20version-0.2.0-green)](https://rubygems.org/gems/graphoid)
 [![Maintainability](https://api.codeclimate.com/v1/badges/96505308310ca4e7e241/maintainability)](https://codeclimate.com/github/maxiperezc/graphoid/maintainability)
 
-Generates a full GraphQL API using introspection of Mongoid or ActiveRecord models.
+Generates a full GraphQL API using introspection of Mongoid models.
 
 ## API Documentation
 The [API Documentation](https://maxcoto.github.io/graphoid/) that displays how to use the queries and mutations that Graphoid automatically generates.
@@ -19,36 +18,35 @@ Please install that gem first before continuing
 Add this line to your Gemfile:
 
 ```ruby
-gem 'graphoid', git: 'https://github.com/oxeanbits/graphoid.git', tag: '0.2.0'
+gem 'graphoid', git: 'https://github.com/oxeanbits/graphoid.git', tag: '1.0.0'
 ```
 
 ```bash
 $ bundle install
 ```
 
-## Database
-Create the file `config/initializers/graphoid.rb`
-And configure the database you want to use in it (:mongoid or :active_record)
-
-```ruby
-Graphoid.configure do |config|
-  config.driver = :mongoid
-end
-```
-
 ## Usage
-You can determine which models will be visible in the API by including the Graphoid Queries and Mutations concerns
+
+Create the file `config/initializers/graphoid.rb` and determine which models will be visible in the
+API by select the models to generate Types, Queries and Mutations.
 
 ```ruby
-class Person
-  include Graphoid::Queries
-  include Graphoid::Mutations
+Rails.application.config.after_initialize do
+  Graphoid.configure do |config|
+    config.driver = :mongoid
+  end
+
+  Graphoid.initialize
+  Graphoid::Types.initialize(User, Contract)
+  Graphoid::Queries.generate(User, Contract)
+  Graphoid::Mutations.generate(User, Contract)
 end
 ```
 
 ## Examples
-You can find an example that uses ActiveRecord in the [Tester AR folder](https://github.com/maxiperezc/graphoid/tree/master/spec/tester_ar)  
-And an example with Mongoid in the [Tester Mongo folder](https://github.com/maxiperezc/graphoid/tree/master/spec/tester_mongo)  
+
+And an example with Mongoid in the
+[Tester Mongo folder](https://github.com/oxeanbits/graphoid/tree/master/spec/tester_mongo)
 In this same repository.
 
 
@@ -70,7 +68,7 @@ In this same repository.
 
 ## Testing
 ```bash
-$ DRIVER=ar DEBUG=true bundle exec rspec
+$ cd spec/tester_mongo
 $ DRIVER=mongo DEBUG=true bundle exec rspec
 ```
 

--- a/lib/graphoid/definitions/inputs.rb
+++ b/lib/graphoid/definitions/inputs.rb
@@ -12,10 +12,13 @@ module Graphoid
           description("Generated model input for #{name}")
 
           Attribute.fields_of(model).each do |field|
-            next if field.name.start_with?('_')
+            next if field.name.start_with?('_') and not field.name == '_id'
+
+            name = field.name
+            name = 'id' if name == '_id'
 
             type = Graphoid::Mapper.convert(field)
-            name = Utils.camelize(field.name)
+            name = Utils.camelize(name)
 
             argument(name, type, required: false)
           end

--- a/lib/graphoid/definitions/types.rb
+++ b/lib/graphoid/definitions/types.rb
@@ -59,6 +59,8 @@ module Graphoid
           Graphoid::Types::const_set(sorter_const, Class.new(GraphQL::Schema::InputObject))
           #Graphoid::Types::const_set(input_const, Class.new(GraphQL::Schema::InputObject))
         end
+
+        models.each { |model| Graphoid.build(model) }
       end
 
       def generate(model)

--- a/lib/graphoid/graphoid.rb
+++ b/lib/graphoid/graphoid.rb
@@ -18,6 +18,7 @@ require 'graphoid/operators/inherited/has_one'
 require 'graphoid/operators/inherited/many_to_many'
 
 require 'graphoid/queries/queries'
+require 'graphoid/queries/pagination'
 require 'graphoid/queries/processor'
 require 'graphoid/queries/operation'
 

--- a/lib/graphoid/mutations/create.rb
+++ b/lib/graphoid/mutations/create.rb
@@ -19,6 +19,7 @@ module Graphoid
           define_method :"#{name}" do |data: {}|
             begin
               user = context[:current_user]
+              model.before_resolve_create(self) if model.respond_to?(:before_resolve_create)
               Graphoid::Mutations::Processor.execute(model, grapho, data, user)
             rescue Exception => ex
               GraphQL::ExecutionError.new(ex.message)

--- a/lib/graphoid/mutations/create.rb
+++ b/lib/graphoid/mutations/create.rb
@@ -19,7 +19,7 @@ module Graphoid
           define_method :"#{name}" do |data: {}|
             begin
               user = context[:current_user]
-              model.before_resolve_create(self) if model.respond_to?(:before_resolve_create)
+              data = model.before_resolve_create(self, data) if model.respond_to?(:before_resolve_create)
               Graphoid::Mutations::Processor.execute(model, grapho, data, user)
             rescue Exception => ex
               GraphQL::ExecutionError.new(ex.message)

--- a/lib/graphoid/mutations/delete.rb
+++ b/lib/graphoid/mutations/delete.rb
@@ -41,6 +41,7 @@ module Graphoid
           define_method :"#{plural}" do |where: {}|
             begin
               objects = Graphoid::Queries::Processor.execute(model, where.to_h)
+              objects = model.resolve_filter(self, objects) if model.respond_to?(:resolve_filter)
               objects.destroy_all
               objects.all.to_a
             rescue Exception => ex

--- a/lib/graphoid/mutations/delete.rb
+++ b/lib/graphoid/mutations/delete.rb
@@ -17,12 +17,32 @@ module Graphoid
           argument :id, GraphQL::Types::ID, required: true
         end
 
+        type.field(name: plural, type: [grapho.type], null: true) do
+          argument :where, grapho.filter, required: false
+        end
+
         type.class_eval do
           define_method :"#{name}" do |id:|
             begin
-              result = model.find(id)
+              result = if model.respond_to?(:resolve_find)
+                         model.resolve_find(self, id)
+                       else
+                         model.find(id)
+                       end
               result.destroy!
               result
+            rescue Exception => ex
+              GraphQL::ExecutionError.new(ex.message)
+            end
+          end
+        end
+
+        type.class_eval do
+          define_method :"#{plural}" do |where: {}|
+            begin
+              objects = Graphoid::Queries::Processor.execute(model, where.to_h)
+              objects.destroy_all
+              objects.all.to_a
             rescue Exception => ex
               GraphQL::ExecutionError.new(ex.message)
             end

--- a/lib/graphoid/mutations/update.rb
+++ b/lib/graphoid/mutations/update.rb
@@ -18,14 +18,37 @@ module Graphoid
           argument :data, grapho.input, required: false
         end
 
+        type.field name: plural, type: [grapho.type], null: true do
+          argument :where, grapho.filter, required: false
+          argument :data, grapho.input, required: false
+        end
+
         type.class_eval do
           define_method :"#{name}" do |id:, data: {}|
             attrs = Utils.build_update_attributes(data, model, context)
 
             begin
-              object = model.find(id)
+              object = if model.respond_to?(:resolve_find)
+                         model.resolve_find(self, id)
+                       else
+                         model.find(id)
+                       end
               object.update!(attrs)
               object.reload
+            rescue Exception => ex
+              GraphQL::ExecutionError.new(ex.message)
+            end
+          end
+        end
+
+        type.class_eval do
+          define_method :"#{plural}" do |where: {}, data: {}|
+            attrs = Utils.build_update_attributes(data, model, context)
+
+            begin
+              objects = Graphoid::Queries::Processor.execute(model, where.to_h)
+              objects.update_all(attrs)
+              objects.all.to_a
             rescue Exception => ex
               GraphQL::ExecutionError.new(ex.message)
             end

--- a/lib/graphoid/operators/attribute.rb
+++ b/lib/graphoid/operators/attribute.rb
@@ -57,14 +57,8 @@ module Graphoid
       end
 
       def correct(model, attributes)
-        result = {}
         fieldnames = fieldnames_of(model)
-        attributes.each do |key, value|
-          key = key.to_s.camelize(:lower) if fieldnames.exclude?(key)
-          key = key.to_s.underscore if fieldnames.exclude?(key.to_s)
-          result[key] = value
-        end
-        result
+        Utils.underscore(attributes, fieldnames)
       end
     end
   end

--- a/lib/graphoid/queries/operation.rb
+++ b/lib/graphoid/queries/operation.rb
@@ -47,6 +47,10 @@ module Graphoid
 
       relation = relations.find { |r| r.name == key.underscore.to_sym }
       return Graphoid.driver.class_of(relation).new(relation) if relation
+
+      if model.include? Mongoid::Attributes::Dynamic
+        return Attribute.new(name: key, type: @value.class) unless @value.nil?
+      end
     end
   end
 end

--- a/lib/graphoid/queries/operation.rb
+++ b/lib/graphoid/queries/operation.rb
@@ -48,7 +48,8 @@ module Graphoid
       relation = relations.find { |r| r.name == key.underscore.to_sym }
       return Graphoid.driver.class_of(relation).new(relation) if relation
 
-      if model.include? Mongoid::Attributes::Dynamic
+      if model.include? Mongoid::Attributes::Dynamic or
+          (model.respond_to?(:klass) and model.klass.include? Mongoid::Attributes::Dynamic)
         return Attribute.new(name: key, type: @value.class) unless @value.nil?
       end
     end

--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -26,13 +26,7 @@ module Graphoid
         # Syntax => name, type, description
         field :count, GraphQL::Types::Int, null: true
 
-        #field :pageSize, !GraphQL::Types::Int, I18n.t('pagination.page_size_hint') do
-        #  resolve lambda { |obj, _args, _ctx|
-        #    return PAGE_SIZE if obj.options[:limit].nil? or obj.options[:limit] > PAGE_SIZE
-
-        #    obj.options[:limit]
-        #  }
-        #end
+        field :pageSize, GraphQL::Types::Int, null: true
 
         #field :pages, !types.Int, I18n.t('pagination.pages_hint') do
         #  resolve lambda { |obj, _args, _ctx|
@@ -51,6 +45,12 @@ module Graphoid
         def data
           return object.eager_load if object.respond_to? :eager_load
           object
+        end
+
+        def page_size
+          return PAGE_SIZE if object.options[:limit].nil? or object.options[:limit] > PAGE_SIZE
+
+          object.options[:limit]
         end
       end
 

--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+module Graphoid
+  module Queries::Pagination
+    PAGE_SIZE = (ENV['PAGE_SIZE'] || 100).to_i
+
+    def self.generate(*models)
+      models.each { |model| Graphoid::Queries::Pagination.build(model) }
+    end
+
+    def self.build(model)
+      Graphoid.initialize
+      grapho = Graphoid.build(model)
+      query_type = ::Types::QueryType
+
+      query_type.field name: grapho.name, type: grapho.type, null: true do
+        argument :id, GraphQL::Types::ID, required: false
+        argument :where, grapho.filter, required: false
+      end
+
+      paginated_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name("#{model.name}Pagination")
+        description('Pagination Type')
+
+        # https://www.rubydoc.info/github/rmosolgo/graphql-ruby/GraphQL/Field
+        # Syntax => name, type, description
+        field :count, GraphQL::Types::Int, null: true
+
+        #field :pageSize, !GraphQL::Types::Int, I18n.t('pagination.page_size_hint') do
+        #  resolve lambda { |obj, _args, _ctx|
+        #    return PAGE_SIZE if obj.options[:limit].nil? or obj.options[:limit] > PAGE_SIZE
+
+        #    obj.options[:limit]
+        #  }
+        #end
+
+        #field :pages, !types.Int, I18n.t('pagination.pages_hint') do
+        #  resolve lambda { |obj, _args, _ctx|
+        #    return 1 if obj.options[:limit].nil?
+
+        #    (obj.count / obj.options[:limit]) + 1
+        #  }
+        #end
+
+        #field :skip, !types.Int, I18n.t('pagination.skip_hint') do
+        #  resolve ->(obj, _args, _ctx) { obj.options[:skip] || 0 }
+        #end
+
+        #field :data, types[grapho.type], I18n.t('pagination.data', name: grapho.name) do
+        #  resolve lambda { |obj, _args, _ctx|
+        #    return obj.eager_load if obj.respond_to? :eager_load
+
+        #    obj
+        #  }
+        #end
+      end
+
+      #query_type.field name: grapho.plural, type: [grapho.type], null: true do
+      #  Graphoid::Argument.query_many(self, grapho.filter, grapho.order, required: false)
+      #end
+
+      #query_type.class_eval do
+      #  # Dynamically defining a resolver method for queries:
+      #  # query {
+      #  # project(id: "5e7b5b9b0b0b0b0b0b0b0b0b", where: { name_regex: "[a-z]" }) {
+      #  #  id
+      #  #  name
+      #  # }
+      #  define_method :"#{grapho.name}" do |id: nil, where: nil|
+      #    begin
+      #      return model.find(id) if id
+      #      Processor.execute(model, where.to_h).first
+      #    rescue Exception => ex
+      #      GraphQL::ExecutionError.new(ex.message)
+      #    end
+      #  end
+      #end
+
+      #query_type.class_eval do
+      #  # Dynamically defining a resolver method for queries:
+      #  # query {
+      #  #  projects(where: { name_contains: "a" }, order: { name: ASC }, limit: 10, skip: 10) {
+      #  #    id
+      #  #    name
+      #  # }
+      #  define_method :"#{grapho.plural}" do |where: nil, order: nil, limit: nil, skip: nil|
+      #    begin
+      #      # irep_node is deprecated
+      #      # maybe use context.ast_node instead
+      #      # but the problem is that it is not the same
+      #      # model = Graphoid.driver.eager_load(context.irep_node, model)
+      #      # https://graphql-ruby.org/fields/introduction.html#extra-field-metadata
+      #      result = Processor.execute(model, where.to_h)
+      #      order = Processor.parse_order(model, order.to_h)
+      #      result = result.order(order).limit(limit)
+      #      Graphoid.driver.skip(result, skip)
+      #    rescue Exception => ex
+      #      GraphQL::ExecutionError.new(ex.message)
+      #    end
+      #  end
+      #end
+
+      query_type.field name: grapho.plural, type: paginated_type, null: true do
+        argument :where, grapho.filter, required: false
+        argument :order, grapho.order, required: false
+        argument :limit, GraphQL::Types::Int, required: false, default_value: PAGE_SIZE,
+          prepare: lambda { |limit, _ctx|
+            limit = PAGE_SIZE if limit > PAGE_SIZE
+            return limit
+          }
+        argument :skip,  GraphQL::Types::Int, required: false
+      end
+
+      query_type.class_eval do
+        # Dynamically defining a resolver method for queries:
+        # query {
+        # project(id: "5e7b5b9b0b0b0b0b0b0b0b0b", where: { name_regex: "[a-z]" }) {
+        #  id
+        #  name
+        # }
+        define_method :"#{grapho.name}" do |id: nil, where: nil|
+          begin
+            return model.find(id) if id
+            Graphoid::Queries::Processor.execute(model, where.to_h).first
+          rescue Exception => ex
+            GraphQL::ExecutionError.new(ex.message)
+          end
+        end
+      end
+
+      query_type.class_eval do
+        # Dynamically defining a resolver method for queries:
+        # query {
+        #  projects(where: { name_contains: "a" }, order: { name: ASC }, limit: 10, skip: 10) {
+        #    id
+        #    name
+        # }
+        define_method :"#{grapho.plural}" do |where: nil, order: nil, limit: nil, skip: nil|
+          begin
+            # irep_node is deprecated
+            # maybe use context.ast_node instead
+            # but the problem is that it is not the same
+            # model = Graphoid.driver.eager_load(context.irep_node, model)
+            # https://graphql-ruby.org/fields/introduction.html#extra-field-metadata
+            result = Graphoid::Queries::Processor.execute(model, where.to_h)
+            order = Graphoid::Queries::Processor.parse_order(model, order.to_h)
+            result = result.order(order).limit(limit)
+            Graphoid.driver.skip(result, skip)
+          rescue Exception => ex
+            GraphQL::ExecutionError.new(ex.message)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -46,13 +46,12 @@ module Graphoid
         #  resolve ->(obj, _args, _ctx) { obj.options[:skip] || 0 }
         #end
 
-        #field :data, types[grapho.type], I18n.t('pagination.data', name: grapho.name) do
-        #  resolve lambda { |obj, _args, _ctx|
-        #    return obj.eager_load if obj.respond_to? :eager_load
+        field :data, [grapho.type], null: true
 
-        #    obj
-        #  }
-        #end
+        def data
+          return object.eager_load if object.respond_to? :eager_load
+          object
+        end
       end
 
       #query_type.field name: grapho.plural, type: [grapho.type], null: true do

--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -31,6 +31,7 @@ module Graphoid
         field :data, [grapho.type], null: true, extras: [:lookahead]
 
         def data(lookahead:)
+          object ||= @object
           # Mongoid::Criteria uses method_missing to send the method to the underlying Model
           # Just implement def self.lookahead(object, lookahead) in your model to manage
           # eager loading

--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -25,21 +25,9 @@ module Graphoid
         # https://www.rubydoc.info/github/rmosolgo/graphql-ruby/GraphQL/Field
         # Syntax => name, type, description
         field :count, GraphQL::Types::Int, null: true
-
-        field :pageSize, GraphQL::Types::Int, null: true
-
-        #field :pages, !types.Int, I18n.t('pagination.pages_hint') do
-        #  resolve lambda { |obj, _args, _ctx|
-        #    return 1 if obj.options[:limit].nil?
-
-        #    (obj.count / obj.options[:limit]) + 1
-        #  }
-        #end
-
-        #field :skip, !types.Int, I18n.t('pagination.skip_hint') do
-        #  resolve ->(obj, _args, _ctx) { obj.options[:skip] || 0 }
-        #end
-
+        field :page_size, GraphQL::Types::Int, null: true
+        field :pages, GraphQL::Types::Int, null: true
+        field :skip, GraphQL::Types::Int, null: true
         field :data, [grapho.type], null: true
 
         def data
@@ -52,52 +40,17 @@ module Graphoid
 
           object.options[:limit]
         end
+
+        def skip
+          object.options[:skip] || 0
+        end
+
+        def pages
+          return 1 if object.options[:limit].nil?
+
+          (object.count / object.options[:limit]) + 1
+        end
       end
-
-      #query_type.field name: grapho.plural, type: [grapho.type], null: true do
-      #  Graphoid::Argument.query_many(self, grapho.filter, grapho.order, required: false)
-      #end
-
-      #query_type.class_eval do
-      #  # Dynamically defining a resolver method for queries:
-      #  # query {
-      #  # project(id: "5e7b5b9b0b0b0b0b0b0b0b0b", where: { name_regex: "[a-z]" }) {
-      #  #  id
-      #  #  name
-      #  # }
-      #  define_method :"#{grapho.name}" do |id: nil, where: nil|
-      #    begin
-      #      return model.find(id) if id
-      #      Processor.execute(model, where.to_h).first
-      #    rescue Exception => ex
-      #      GraphQL::ExecutionError.new(ex.message)
-      #    end
-      #  end
-      #end
-
-      #query_type.class_eval do
-      #  # Dynamically defining a resolver method for queries:
-      #  # query {
-      #  #  projects(where: { name_contains: "a" }, order: { name: ASC }, limit: 10, skip: 10) {
-      #  #    id
-      #  #    name
-      #  # }
-      #  define_method :"#{grapho.plural}" do |where: nil, order: nil, limit: nil, skip: nil|
-      #    begin
-      #      # irep_node is deprecated
-      #      # maybe use context.ast_node instead
-      #      # but the problem is that it is not the same
-      #      # model = Graphoid.driver.eager_load(context.irep_node, model)
-      #      # https://graphql-ruby.org/fields/introduction.html#extra-field-metadata
-      #      result = Processor.execute(model, where.to_h)
-      #      order = Processor.parse_order(model, order.to_h)
-      #      result = result.order(order).limit(limit)
-      #      Graphoid.driver.skip(result, skip)
-      #    rescue Exception => ex
-      #      GraphQL::ExecutionError.new(ex.message)
-      #    end
-      #  end
-      #end
 
       query_type.field name: grapho.plural, type: paginated_type, null: true do
         argument :where, grapho.filter, required: false

--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -48,7 +48,7 @@ module Graphoid
         def pages
           return 1 if object.options[:limit].nil?
 
-          (object.count / object.options[:limit]) + 1
+          (object.count / object.options[:limit].to_f).ceil
         end
       end
 

--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -28,9 +28,14 @@ module Graphoid
         field :page_size, GraphQL::Types::Int, null: true
         field :pages, GraphQL::Types::Int, null: true
         field :skip, GraphQL::Types::Int, null: true
-        field :data, [grapho.type], null: true
+        field :data, [grapho.type], null: true, extras: [:lookahead]
 
-        def data
+        def data(lookahead:)
+          # Mongoid::Criteria uses method_missing to send the method to the underlying Model
+          # Just implement def self.lookahead(object, lookahead) in your model to manage
+          # eager loading
+          obj = object.lookahead(object, lookahead) if object.respond_to? :lookahead
+          object = obj if obj
           return object.eager_load if object.respond_to? :eager_load
           object
         end

--- a/lib/graphoid/queries/queries.rb
+++ b/lib/graphoid/queries/queries.rb
@@ -34,7 +34,7 @@ module Graphoid
         # }
         define_method :"#{grapho.name}" do |id: nil, where: nil|
           begin
-              return model.resolve_one(self, id, where) if model.respond_to?(:resolve_one)
+            return model.resolve_one(self, id, where) if model.respond_to?(:resolve_one)
             return model.find(id) if id
             Processor.execute(model, where.to_h).first
           rescue Exception => ex

--- a/lib/graphoid/queries/queries.rb
+++ b/lib/graphoid/queries/queries.rb
@@ -34,6 +34,7 @@ module Graphoid
         # }
         define_method :"#{grapho.name}" do |id: nil, where: nil|
           begin
+              return model.resolve_one(self, id, where) if model.respond_to?(:resolve_one)
             return model.find(id) if id
             Processor.execute(model, where.to_h).first
           rescue Exception => ex
@@ -56,6 +57,10 @@ module Graphoid
             # but the problem is that it is not the same
             # model = Graphoid.driver.eager_load(context.irep_node, model)
             # https://graphql-ruby.org/fields/introduction.html#extra-field-metadata
+            if model.respond_to?(:resolve_many)
+              return model.resolve_many(self, where, order, limit, skip)
+            end
+
             result = Processor.execute(model, where.to_h)
             order = Processor.parse_order(model, order.to_h)
             result = result.order(order).limit(limit)

--- a/lib/graphoid/queries/queries.rb
+++ b/lib/graphoid/queries/queries.rb
@@ -20,6 +20,11 @@ module Graphoid
         Graphoid::Argument.query_many(self, grapho.filter, grapho.order, required: false)
       end
 
+      Graphoid::Queries.define_resolvers(query_type, model, grapho.name, grapho)
+
+    end
+
+    def self.define_resolvers(query_type, model, name, grapho)
       query_type.class_eval do
         # Dynamically defining a resolver method for queries:
         # query {
@@ -63,4 +68,3 @@ module Graphoid
     end
   end
 end
-

--- a/lib/graphoid/utils.rb
+++ b/lib/graphoid/utils.rb
@@ -34,6 +34,14 @@ module Graphoid
           key = key.to_s if key.is_a? Symbol
           key = key.camelize(:lower) if fields.exclude?(key)
           key = key.underscore if fields.exclude?(key)
+          # embeds many is passing on update action an array of dynamic object like hash
+          if value.is_a? Array
+            value = value.map do |v|
+              transformed = v
+              transformed = v.to_h if v.respond_to?(:to_h)
+              transformed
+            end
+          end
           attrs[key] = value
         end
         attrs

--- a/lib/graphoid/utils.rb
+++ b/lib/graphoid/utils.rb
@@ -42,6 +42,10 @@ module Graphoid
               transformed
             end
           end
+
+          if value.is_a? GraphQL::Schema::InputObject
+            value = value.to_h
+          end
           attrs[key] = value
         end
         attrs

--- a/spec/tester_mongo/app/models/account.rb
+++ b/spec/tester_mongo/app/models/account.rb
@@ -59,7 +59,14 @@ class Account
     data
   end
 
-  def self.resolve_find(model, id)
+  def self.resolve_find(resolver, id)
     where.not(string_field: 'hook').find(id)
+  end
+
+  def self.resolve_one(resolver, id, filter)
+    result = where.not(string_field: 'hook')
+    result = Graphoid::Queries::Processor.execute(result, filter.to_h)
+    return result.find(id) if id
+    result.first
   end
 end

--- a/spec/tester_mongo/app/models/account.rb
+++ b/spec/tester_mongo/app/models/account.rb
@@ -48,4 +48,14 @@ class Account
 
   embeds_one :value
   embeds_many :snakes
+
+  def self.before_resolve_create(model, data)
+    if data[:string_field] == 'hook'
+      data = data.to_h
+      data[:string_field] = 'hook_changed'
+      return data
+    end
+
+    data
+  end
 end

--- a/spec/tester_mongo/app/models/account.rb
+++ b/spec/tester_mongo/app/models/account.rb
@@ -58,4 +58,8 @@ class Account
 
     data
   end
+
+  def self.resolve_find(model, id)
+    where.not(string_field: 'hook').find(id)
+  end
 end

--- a/spec/tester_mongo/app/models/level.rb
+++ b/spec/tester_mongo/app/models/level.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Level
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+
+  has_many :accounts, dependent: :destroy
+end

--- a/spec/tester_mongo/app/models/level.rb
+++ b/spec/tester_mongo/app/models/level.rb
@@ -5,6 +5,4 @@ class Level
   include Mongoid::Timestamps
 
   field :name, type: String
-
-  has_many :accounts, dependent: :destroy
 end

--- a/spec/tester_mongo/app/models/player.rb
+++ b/spec/tester_mongo/app/models/player.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Player
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+  field :email, type: String
+  field :active, type: Boolean, default: true
+
+  def self.resolve_many(resolver, where_args, order, limit, skip)
+    w = where_args.to_h
+    w[:active] = true
+    result = Graphoid::Queries::Processor.execute(self, w)
+    order = Graphoid::Queries::Processor.parse_order(self, order.to_h)
+    result = result.order(order).limit(limit)
+    Graphoid.driver.skip(result, skip)
+  end
+end

--- a/spec/tester_mongo/app/models/value_nested.rb
+++ b/spec/tester_mongo/app/models/value_nested.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-class Value
+class ValueNested
   include Mongoid::Document
   include Mongoid::Timestamps
 
   field :text, type: String
   field :name, type: String
 
-  embeds_many :value_nested
-  embedded_in :account
+  embedded_in :value
 end

--- a/spec/tester_mongo/config/initializers/graphoid.rb
+++ b/spec/tester_mongo/config/initializers/graphoid.rb
@@ -6,9 +6,9 @@ Rails.application.config.after_initialize do
   end
 
   Graphoid.initialize
-  Graphoid::Types.initialize(User, House, Label, Snake, Value, Person, Account, Contract, Level,
+  Graphoid::Types.initialize(User, House, Label, Snake, ValueNested, Value, Person, Account, Contract, Level,
                              Player)
-  Graphoid::Queries.generate(User, House, Label, Snake, Value, Person, Account, Contract, Player)
-  Graphoid::Mutations.generate(User, House, Label, Snake, Value, Person, Account, Contract)
+  Graphoid::Queries.generate(User, House, Label, Snake, ValueNested, Value, Person, Account, Contract, Player)
+  Graphoid::Mutations.generate(User, House, Label, Snake, Value, ValueNested, Person, Account, Contract)
   Graphoid::Queries::Pagination.generate(Level)
 end

--- a/spec/tester_mongo/config/initializers/graphoid.rb
+++ b/spec/tester_mongo/config/initializers/graphoid.rb
@@ -6,8 +6,8 @@ Rails.application.config.after_initialize do
   end
 
   Graphoid.initialize
-  Graphoid::Types.initialize(User, House, Label, Snake, Value, Person, Account, Contract)
-  Graphoid::Queries.generate(House, Label, Snake, Value, Person, Account, Contract)
-  Graphoid::Queries::Pagination.generate(User)
+  Graphoid::Types.initialize(User, House, Label, Snake, Value, Person, Account, Contract, Level)
+  Graphoid::Queries.generate(User, House, Label, Snake, Value, Person, Account, Contract)
   Graphoid::Mutations.generate(User, House, Label, Snake, Value, Person, Account, Contract)
+  Graphoid::Queries::Pagination.generate(Level)
 end

--- a/spec/tester_mongo/config/initializers/graphoid.rb
+++ b/spec/tester_mongo/config/initializers/graphoid.rb
@@ -7,6 +7,7 @@ Rails.application.config.after_initialize do
 
   Graphoid.initialize
   Graphoid::Types.initialize(User, House, Label, Snake, Value, Person, Account, Contract)
-  Graphoid::Queries.generate(User, House, Label, Snake, Value, Person, Account, Contract)
+  Graphoid::Queries.generate(House, Label, Snake, Value, Person, Account, Contract)
+  Graphoid::Queries::Pagination.generate(User)
   Graphoid::Mutations.generate(User, House, Label, Snake, Value, Person, Account, Contract)
 end

--- a/spec/tester_mongo/config/initializers/graphoid.rb
+++ b/spec/tester_mongo/config/initializers/graphoid.rb
@@ -6,8 +6,9 @@ Rails.application.config.after_initialize do
   end
 
   Graphoid.initialize
-  Graphoid::Types.initialize(User, House, Label, Snake, Value, Person, Account, Contract, Level)
-  Graphoid::Queries.generate(User, House, Label, Snake, Value, Person, Account, Contract)
+  Graphoid::Types.initialize(User, House, Label, Snake, Value, Person, Account, Contract, Level,
+                             Player)
+  Graphoid::Queries.generate(User, House, Label, Snake, Value, Person, Account, Contract, Player)
   Graphoid::Mutations.generate(User, House, Label, Snake, Value, Person, Account, Contract)
   Graphoid::Queries::Pagination.generate(Level)
 end

--- a/spec/tester_mongo/spec/graphoid/mutations/create_embeds_many_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/create_embeds_many_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'MutationCreateNested', type: :request do
+  before { Account.delete_all }
+  subject { Helper.resolve(self, 'createAccount', @query) }
+
+  it 'creates one object with referenced relations' do
+    @query = %{
+      mutation {
+        createAccount(data: {
+          stringField: "bob",
+          person: { name: "Bryan" },
+          snakes: [{ name: "a", camelCase: 1 }, { name: "b", camelCase: 2 }],
+          house: { name: "Alesi" }
+        }) {
+          id
+          person {
+            id
+          }
+          labels {
+            id
+          }
+        }
+      }
+    }
+
+    persisted = Account.find(subject['id'])
+    persisted.reload
+
+    expect(persisted.snakes.size).to be_eql(2)
+    expect(persisted.snakes.first.name).to be_eql('a')
+    expect(persisted.snakes.first.camelCase).to be_eql(1)
+    expect(persisted.snakes.last.name).to be_eql('b')
+    expect(persisted.snakes.last.camelCase).to be_eql(2)
+    expect(persisted.person.name).to eq('Bryan')
+  end
+end

--- a/spec/tester_mongo/spec/graphoid/mutations/create_embeds_many_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/create_embeds_many_spec.rb
@@ -13,6 +13,7 @@ describe 'MutationCreateNested', type: :request do
           stringField: "bob",
           person: { name: "Bryan" },
           snakes: [{ name: "a", camelCase: 1 }, { name: "b", camelCase: 2 }],
+          value: { text: "a", name: "b", valueNested: [{ text: "c", name: "d" }] }
           house: { name: "Alesi" }
         }) {
           id

--- a/spec/tester_mongo/spec/graphoid/mutations/create_embeds_many_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/create_embeds_many_spec.rb
@@ -19,7 +19,7 @@ describe 'MutationCreateNested', type: :request do
           person {
             id
           }
-          labels {
+          snakes {
             id
           }
         }

--- a/spec/tester_mongo/spec/graphoid/mutations/create_one_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/create_one_spec.rb
@@ -51,4 +51,21 @@ describe 'MutationCreateOne', type: :request do
     expect(persisted.created_by.name).to eq('maxi')
     expect(persisted.updated_by.name).to eq('maxi')
   end
+
+  it 'change fields using the before_resolve_create hook' do
+    @action = 'createAccount'
+
+    @query = %{
+      mutation {
+        createAccount(data: {
+          stringField: "hook"
+        }) {
+          id
+        }
+      }
+    }
+
+    persisted = Account.find(subject['id'])
+    expect(persisted.string_field).to eq('hook_changed')
+  end
 end

--- a/spec/tester_mongo/spec/graphoid/mutations/delete_many_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/delete_many_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'MutationDeleteMany', type: :request do
+  before { Account.delete_all }
+  subject { Helper.resolve(self, @action, @query) }
+
+  let!(:a0) { Account.create!(string_field: 'bob') }
+  let!(:a1) { Account.create!(string_field: 'bob') }
+  let!(:a2) { Account.create!(string_field: 'oob') }
+
+  it 'deletes many objects by condition' do
+    @action = 'deleteManyAccounts'
+
+    @query = %{
+      mutation {
+        deleteManyAccounts(where: { stringField: "bob" }){
+          id
+        }
+      }
+    }
+
+    expect(Account.count).to eq(3)
+    subject
+    expect(Account.count).to eq(1)
+    expect(Account.first.string_field).to eq('oob')
+  end
+end

--- a/spec/tester_mongo/spec/graphoid/mutations/update_many_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/update_many_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'MutationUpdateMany', type: :request do
+  before { Account.delete_all }
+  subject { Helper.resolve(self, 'updateManyAccounts', @query) }
+
+  let!(:a0) { Account.create!(string_field: 'account0', snake_case: 'snake', camelCase: 'camel') }
+  let!(:a1) { Account.create!(string_field: 'account1', snake_case: 'snake', camelCase: 'camel') }
+  let!(:a2) { Account.create!(string_field: 'account2', snake_case: 'snaki', camelCase: 'camel') }
+
+  it 'updates many objects by condition' do
+    @query = %{
+      mutation M {
+        updateManyAccounts(where: { snakeCase: "snake" }, data: { camelCase: "updated" }){
+          id
+          camelCase
+        }
+      }
+    }
+
+    expect(subject[0]['camelCase']).to eq('updated')
+    expect(subject[1]['camelCase']).to eq('updated')
+    expect(a2.reload.camelCase).to eq('camel')
+  end
+end

--- a/spec/tester_mongo/spec/graphoid/mutations/update_one_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/update_one_spec.rb
@@ -50,4 +50,58 @@ describe 'MutationUpdateOne', type: :request do
     persisted = Account.find(subject['id'])
     expect(persisted.updated_by.name).to eq('maxi')
   end
+
+  it 'updates and sets updated_by if exists' do
+    @action = 'updateAccount'
+
+    @query = %{
+      mutation {
+        updateAccount(id: "#{account.id}", data: {
+          integerField: 5
+        }) {
+          id
+        }
+      }
+    }
+
+    persisted = Account.find(subject['id'])
+    expect(persisted.updated_by.name).to eq('maxi')
+  end
+
+  describe 'intercepting the updated object' do
+    it 'updates the right object' do
+      @action = 'updateAccount'
+
+      @query = %{
+        mutation {
+          updateAccount(id: "#{account.id}", data: {
+            integerField: 5
+          }) {
+            id
+          }
+        }
+      }
+
+      persisted = Account.find(subject['id'])
+      expect(persisted.updated_by.name).to eq('maxi')
+    end
+
+    it 'it blocks an update' do
+      account.set(string_field: 'hook')
+
+      @action = 'updateAccount'
+
+      @query = %{
+        mutation {
+          updateAccount(id: "#{account.id}", data: {
+            integerField: 5
+          }) {
+            id
+          }
+        }
+      }
+
+      expect(subject).to be_nil
+    end
+  end
 end

--- a/spec/tester_mongo/spec/graphoid/queries/attributes/types_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/queries/attributes/types_spec.rb
@@ -13,7 +13,7 @@ describe 'QueryFieldTypes', type: :request do
   it 'loads one object by id' do
     @query = %{
       query {
-        account(id: "#{a0.id}" ){
+        account(id: "#{a0.id}"){
           id
           integerField
           floatField
@@ -39,12 +39,27 @@ describe 'QueryFieldTypes', type: :request do
   it 'loads one object by condition' do
     @query = %{
       query {
-        account(where: { stringField_contains: "bobi" } ){
+        account(where: { stringField_contains: "bobi" }){
           id
         }
       }
     }
 
     expect(subject['id']).to eq(a1.id.to_s)
+  end
+
+  it 'filter the object by intercepting using resolve_one' do
+    a0.set(string_field: 'hook')
+
+    @query = %{
+      query {
+        account(where: { integerField: 4 }){
+          id
+        }
+      }
+    }
+    post '/graphql', params: { query: @query }
+
+    expect(JSON.parse(body)).to match({ 'data' => { 'account' => nil }})
   end
 end

--- a/spec/tester_mongo/spec/graphoid/queries/pagination_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/queries/pagination_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GraphqlController, type: :controller do
+  before { Level.delete_all }
+  describe 'POST #execute' do
+    let(:query) do |example|
+      limit = example.metadata[:limit]
+      skip_param = example.metadata[:skip_param]
+
+      <<-GRAPHQL
+        {
+          levels(where: { name_contains: "1", createdAt_gt: "2023-04-01" }, order: { name: DESC}, limit: #{limit}, skip: #{skip_param}) {
+            count
+            pageSize
+            pages
+            data {
+              id
+              name
+              createdAt
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    let!(:level1) { Level.create!(name: 'Level 1A', created_at: '2023-04-02') }
+    let!(:level2) { Level.create!(name: 'Level 1B', created_at: '2023-04-03') }
+    let!(:level3) { Level.create!(name: 'Level 1C', created_at: '2023-04-04') }
+    let!(:level4) { Level.create!(name: 'Level 2A', created_at: '2023-04-02') }
+
+    context 'with valid query', limit: 2, skip_param: 0 do
+      before do
+        post :execute, params: { query: query }
+      end
+
+      it 'returns a 200 status code' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns the expected levels' do
+        expect(JSON.parse(response.body)['data']['levels']).to match(
+          'count' => 3,
+          'pageSize' => 2,
+          'pages' => 2,
+          'data' => [
+            {
+              'id' => level3.id.to_s,
+              'name' => level3.name,
+              'createdAt' => level3.created_at.iso8601(3)
+            },
+            {
+              'id' => level2.id.to_s,
+              'name' => level2.name,
+              'createdAt' => level2.created_at.iso8601(3)
+            }
+          ]
+        )
+      end
+    end
+
+    context 'with different pagination params', limit: 1, skip_param: 1 do
+      before do
+        post :execute, params: { query: query }
+      end
+
+      it 'returns a 200 status code' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns the expected levels' do
+        expect(JSON.parse(response.body)['data']['levels']).to match(
+          'count' => 3,
+          'pageSize' => 1,
+          'pages' => 3,
+          'data' => [
+            {
+              'id' => level2.id.to_s,
+              'name' => level2.name,
+              'createdAt' => level2.created_at.iso8601(3)
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/tester_mongo/spec/graphoid/queries/relations/embeds_many_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/queries/relations/embeds_many_spec.rb
@@ -3,17 +3,23 @@
 require 'rails_helper'
 
 describe 'QueryEmbedsMany', type: :request do
-  let!(:delete) { Account.delete_all; Label.delete_all }
+  let!(:delete) { Account.delete_all; }
   subject { Helper.resolve(self, 'accounts', @query) }
 
-  let!(:a0) { Account.create!(string_field: 'bob') }
-  let!(:a1) { Account.create!(string_field: 'bob') }
-  let!(:a2) { Account.create!(string_field: 'boc') }
+  let!(:a0) do
+    Account.create!(string_field: 'bob', snakes: [])
+  end
+  let!(:a1) do
+    Account.create!(string_field: 'bob', snakes: [])
+  end
+  let!(:a2) do
+    Account.create!(string_field: 'boc', snakes: [])
+  end
 
   let!(:s0) { Snake.create!(name: 'a', camelCase: 1, snake_case: 1.0, account: a0) }
   let!(:s1) { Snake.create!(name: 'a', camelCase: 2, snake_case: 1.0, account: a0) }
   let!(:s2) { Snake.create!(name: 'b', camelCase: 1, snake_case: 1.0, account: a1) }
-  let!(:s3) { Snake.create!(name: 'a', camelCase: 2, snake_case: 2.0, account: a1) }
+  let!(:s3) { Snake.create!(name: 'b', camelCase: 2, snake_case: 2.0, account: a1) }
   let!(:s4) { Snake.create!(name: 'c', camelCase: 1, snake_case: 1.0, account: a2) }
   let!(:s5) { Snake.create!(name: 'a', camelCase: 2, snake_case: 2.0, account: a2) }
 
@@ -26,79 +32,17 @@ describe 'QueryEmbedsMany', type: :request do
             snakes_some: { name: "a", camelCase: 1 }
           }) {
             id
-            labels {
-              id
-            }
-          }
-        }
-      }
-      # TODO: Not Implemented
-      pending
-      raise
-
-      if ENV['DRIVER'] == 'mongo'
-        expect(subject.size).to eq(1)
-        expect(subject[0]['id']).to eq a0.id.to_s
-        expect(subject[0]['labels'][0]['id']).to eq s0.id.to_s
-        expect(subject[0]['labels'][1]['id']).to eq s1.id.to_s
-      end
-    end
-
-    it 'filters _none' do
-      @query = %{
-        query {
-          accounts(where: {
-            snakes_none: { snakeCase: 1.0, camelCase: 2 }
-          }) {
-            id
-            labels {
+            snakes {
               id
             }
           }
         }
       }
 
-      if ENV['DRIVER'] == 'mongo'
-        # TODO: Not Implemented
-        pending
-        raise
-
-        expect(subject.size).to eq(2)
-        expect(subject[0]['id']).to eq a1.id.to_s
-        expect(subject[1]['id']).to eq a2.id.to_s
-
-        expect(subject[0]['labels'][0]['id']).to eq s2.id.to_s
-        expect(subject[0]['labels'][1]['id']).to eq s3.id.to_s
-
-        expect(subject[1]['labels'][0]['id']).to eq s4.id.to_s
-        expect(subject[1]['labels'][1]['id']).to eq s5.id.to_s
-      end
-    end
-
-    it 'filters _every' do
-      @query = %{
-        query {
-          accounts(where: {
-            snakes_every: { snakeCase: "a", camelCase: "b" }
-          }) {
-            id
-            labels {
-              id
-            }
-          }
-        }
-      }
-
-      if ENV['DRIVER'] == 'mongo'
-        # TODO: Not Implemented
-        pending
-        raise
-
-        expect(subject.size).to eq(1)
-        expect(subject[0]['id']).to eq a2.id.to_s
-        expect(subject[0]['snakes'][0]['id']).to eq s4.id.to_s
-        expect(subject[0]['snakes'][1]['id']).to eq s5.id.to_s
-      end
+      expect(subject.size).to eq(1)
+      expect(subject[0]['id']).to eq a0.id.to_s
+      expect(subject[0]['snakes'][0]['id']).to eq s0.id.to_s
+      expect(subject[0]['snakes'][1]['id']).to eq s1.id.to_s
     end
   end
 end

--- a/spec/tester_mongo/spec/graphoid/queries/resolve_many_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/queries/resolve_many_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GraphqlController, type: :controller do
+  before { Player.delete_all }
+  describe 'POST #execute' do
+    let(:query) do |example|
+      limit = example.metadata[:limit]
+      skip_param = example.metadata[:skip_param]
+
+      <<-GRAPHQL
+        {
+          players(where: { email_contains: "player" }) {
+            id
+            name
+            email
+          }
+        }
+      GRAPHQL
+    end
+
+    let!(:player1) { Player.create!(name: 'Player 1A', email: 'player1a@gmail.com') }
+    let!(:player2) { Player.create!(name: 'Player 1B', email: 'player1b@gmail.com') }
+    let!(:player3) { Player.create!(name: 'Player 1C', email: 'player1c@dbz.com', active: false) }
+    let!(:player4) { Player.create!(name: 'Player 2A', email: 'player2a@dbz.com', active: false) }
+
+    context 'with valid query', limit: 2, skip_param: 0 do
+      before do
+        post :execute, params: { query: query }
+      end
+
+      it 'returns a 200 status code' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns the expected levels' do
+        expect(JSON.parse(response.body)['data']['players']).to match(
+          [
+            {
+              'id' => player1.id.to_s,
+              'name' => player1.name,
+              'email' => player1.email,
+            },
+            {
+              'id' => player2.id.to_s,
+              'name' => player2.name,
+              'email' => player2.email,
+            }
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

* Pagination: Adds a new Pagination module for paginated query results, along with the corresponding paginated_type object for each model. The default page size is now configurable through the PAGE_SIZE environment variable.
* Custom resolvers: Allows users to define custom resolvers for the find, filter, create, and update actions. This enables more granular control over how objects are retrieved, created, and updated.
* Dynamic attribute handling: Properly handles dynamic attributes from models that include Mongoid::Attributes::Dynamic. Also adds utility functions for underscore and camelize transformations.
* Bug fixes: Fixes a bug where the _id field was being ignored in input arguments, and another where the field names were not being properly camelized.

# Overview 🔍

## How to use the new features in the GraphQL library

This guide will walk you through using the new features introduced in the GraphQL library, including pagination, custom resolvers, and dynamic attribute handling.

### Pagination

The new pagination feature allows you to fetch a specific page of results with a specified number of items per page. To use it, follow these steps:

1. In your GraphQL query, use the pluralized form of the model name, which will return a paginated type.
2. Provide the `limit` and `skip` arguments to specify the number of items per page and the number of items to skip, respectively.

Example query for fetching paginated results:

```graphql
query {
  products(limit: 10, skip: 20) {
    count
    pageSize
    pages
    skip
    data {
      id
      name
      price
    }
  }
}
```

### Custom Resolvers

You can now define custom resolvers for `find`, `filter`, `create`, and `update` actions. Here's how to do it:

1. In your model, define a class method for the action you want to customize, such as `resolve_find`, `resolve_filter`, `resolve_one`, or `resolve_many`. The method should take the necessary arguments based on the action.
2. Implement the custom logic for the resolver within the method.

Example of defining a custom `resolve_find` resolver in the `Product` model:

```ruby
class Product
  # ...

  def self.resolve_find(context, id)
    # Custom logic for finding a product by ID
    find_by(custom_id: id)
  end
end
```

### Dynamic Attribute Handling

The library now properly handles dynamic attributes for models that include `Mongoid::Attributes::Dynamic`. To work with dynamic attributes, simply use them in your queries and mutations as you would with regular attributes.

Example of querying a model with dynamic attributes:

```graphql
query {
  product(id: "123") {
    id
    name
    dynamicAttribute
  }
}
```

That's it! You're now ready to use the new features in the GraphQL library. Enjoy the enhanced flexibility and customization options in your GraphQL API.


# Checks ☑️

- Updates readme to reflect latest changes
- Query with pagination skip, limit, pages
- Generate grapho builds during initializer
- Enable dynamic defined fields in mongoid with dynamic enabled
- Enabling back updateMany and deleteMany
- Fix embeds many values transformation on update
- Allow to hook before creation
- Allow to filter objects before deletemany
- Fix dynamic attributes for mongoid criterias
- Allowing to hook data before create
- Enable lookahead feature for pagination data
- Converting input objects to hash
