### PR TITLE
Split resolve find between update and delete

### DIFF
--- a/lib/graphoid/mutations/delete.rb
+++ b/lib/graphoid/mutations/delete.rb
@@ -24,8 +24,8 @@ module Graphoid
         type.class_eval do
           define_method :"#{name}" do |id:|
             begin
-              result = if model.respond_to?(:resolve_find)
-                         model.resolve_find(self, id)
+              result = if model.respond_to?(:resolve_find_before_delete)
+                         model.resolve_find_before_delete(self, id)
                        else
                          model.find(id)
                        end

--- a/lib/graphoid/mutations/update.rb
+++ b/lib/graphoid/mutations/update.rb
@@ -28,8 +28,8 @@ module Graphoid
             attrs = Utils.build_update_attributes(data, model, context)
 
             begin
-              object = if model.respond_to?(:resolve_find)
-                         model.resolve_find(self, id)
+              object = if model.respond_to?(:resolve_find_before_update)
+                         model.resolve_find_before_update(self, id)
                        else
                          model.find(id)
                        end

--- a/spec/tester_mongo/app/models/account.rb
+++ b/spec/tester_mongo/app/models/account.rb
@@ -59,7 +59,11 @@ class Account
     data
   end
 
-  def self.resolve_find(resolver, id)
+  def self.resolve_find_before_update(resolver, id)
+    where.not(string_field: 'hook').find(id)
+  end
+
+  def self.resolve_find_before_delete(resolver, id)
     where.not(string_field: 'hook').find(id)
   end
 


### PR DESCRIPTION
# Description ✍️

In the current implementation of the Graphoid gem, the `resolve_find` method was used in both the
Update and Delete operations. However, this approach might not be optimal in cases where these
operations need different processing or business logic. This pull request aims to address this by
splitting the `resolve_find` method into two separate methods, namely `resolve_find_before_update` and
`resolve_find_before_delete`, to handle the resolution of the item to be updated or deleted
respectively.

The changes include:

In `delete.rb` and `update.rb`, replaced calls to `resolve_find` with `resolve_find_before_delete` and
`resolve_find_before_update` respectively. In account.rb, refactored `resolve_find` into
`resolve_find_before_update` and `resolve_find_before_delete`. 
The new methods allow for separate processing logic before an update or a delete operation. For now, both methods use the same logic as the original `resolve_find method`, as an example. These changes increase the flexibility of the
Graphoid gem and allow for greater customization in handling different operations on models.

```ruby
class User < ApplicationRecord
  def resolve_find_before_update(resolve, id)
    # ....
  end

  def resolve_find_before_delete(resolve, id)
    # ....
  end
end
```
