### PR TITLE
Fix performance when build_operand for dynamic attributes

### DIFF
--- a/graphoid.gemspec
+++ b/graphoid.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.push File.expand_path('lib', __dir__)
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |gem|
   gem.name        = 'graphoid'
-  gem.version     = '1.3.0'
+  gem.version     = '1.3.1'
   gem.authors     = ['Nilton Vasques', 'Maximiliano Perez Coto']
   gem.email       = ['nilton.vasques@gmail.com']
   gem.homepage    = 'https://github.com/oxeanbits/graphoid'

--- a/lib/graphoid/queries/operation.rb
+++ b/lib/graphoid/queries/operation.rb
@@ -48,8 +48,9 @@ module Graphoid
       relation = relations.find { |r| r.name == key.underscore.to_sym }
       return Graphoid.driver.class_of(relation).new(relation) if relation
 
-      if model.include? Mongoid::Attributes::Dynamic or
-          (model.respond_to?(:klass) and model.klass.include? Mongoid::Attributes::Dynamic)
+      mongoid_criteria = model.respond_to?(:klass)
+      kklass = mongoid_criteria ? model.klass : model
+      if kklass.include? Mongoid::Attributes::Dynamic
         return Attribute.new(name: key, type: @value.class) unless @value.nil?
       end
     end

--- a/spec/tester_mongo/Gemfile.lock
+++ b/spec/tester_mongo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    graphoid (1.3.0)
+    graphoid (1.3.1)
       graphql (~> 2.0.21)
       rails (>= 6.0)
 

--- a/spec/tester_mongo_rails_6/Gemfile.lock
+++ b/spec/tester_mongo_rails_6/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    graphoid (1.3.0)
+    graphoid (1.3.1)
       graphql (~> 2.0.21)
       rails (>= 6.0)
 


### PR DESCRIPTION
# Description ✍️

Improve the `build_operand` performance for dynamic attributes by avoid an unecessary call for
include? method.

Before when using include? method for a Mongoid::Criteria, it was triggering an useless
getMore query for Mongo db. Example:

```
[dfd90178-0ec0-4fb5-96bb-976c35a73fa3] MONGODB | mongo:27017 req:1741 | database-prod-db.getMore
| SUCCEEDED | 0.050s D, [2023-06-27T08:22:43.076259 #154900] DEBUG -- :
[7e1a125e-9fb2-4d85-865b-fb3946ffa991] MONGODB | mongo1:30001 req:1758 conn:1:1 sconn:560 |
database-prod-db.getMore | STARTED | {"getMore"=>#<BSON::Int64:0x00007fc9a636df90
@value=3664912834551063330>, "collection"=>"my_entries", "$db"=>"database-prod-db",
"$clusterTime"=>{"clusterTime"=>#<BSON::Timestamp:0x00007fc9a66c5198 @seconds=1687864959,
@increment=1>, "signature"=>{"hash"=><BSON::Binary:0x73580 type=generic data=0x0000000000000000...>,
"keyId"=>0}}, "lsid"=>{"id"=><BSON::Binary:0x63220 type=uuid data=0xbbc0bfa3cfea4d82...>}}
```
