### PR TITLE
Create resolve_find_before_create_or_update Resolver

### DIFF
--- a/lib/graphoid/mutations/create_or_update.rb
+++ b/lib/graphoid/mutations/create_or_update.rb
@@ -21,8 +21,8 @@ module Graphoid
             begin
               user = context[:current_user]
 
-              object = if model.respond_to?(:resolve_one)
-                          model.resolve_one(self, nil, where.to_h)
+              object = if model.respond_to?(:resolve_find_before_create_or_update)
+                          model.resolve_find_before_create_or_update(self, where.to_h)
                         else
                           model.where(where.to_h).first
                         end

--- a/spec/tester_mongo/app/models/account.rb
+++ b/spec/tester_mongo/app/models/account.rb
@@ -67,6 +67,10 @@ class Account
     where.not(string_field: 'hook').find(id)
   end
 
+  def self.resolve_find_before_create_or_update(resolver, filter)
+    resolve_one(resolver, nil, filter)
+  end
+
   def self.resolve_one(resolver, id, filter)
     result = where.not(string_field: 'hook')
     result = Graphoid::Queries::Processor.execute(result, filter.to_h)

--- a/spec/tester_mongo/spec/graphoid/mutations/create_or_update_one_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/create_or_update_one_spec.rb
@@ -100,7 +100,8 @@ describe 'MutationCreateOrUpdate', type: :request do
 
   context 'intercepting the matching record' do
     it 'does not find the matching record and creates an object' do
-      existing = Account.create!(string_field: 'hook', integerField: 5)
+      existing = Account.create!(integerField: 5)
+      existing.set(string_field: 'hook')
       
       @query = %{
         mutation {

--- a/spec/tester_mongo/spec/graphoid/mutations/create_or_update_one_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/create_or_update_one_spec.rb
@@ -100,8 +100,7 @@ describe 'MutationCreateOrUpdate', type: :request do
 
   context 'intercepting the matching record' do
     it 'does not find the matching record and creates an object' do
-      existing = Account.create!(integerField: 5)
-      existing.set(string_field: 'hook')
+      existing = Account.create!(string_field: 'hook', integer_field: 5)
       
       @query = %{
         mutation {

--- a/spec/tester_mongo/spec/graphoid/mutations/create_or_update_one_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/mutations/create_or_update_one_spec.rb
@@ -97,4 +97,29 @@ describe 'MutationCreateOrUpdate', type: :request do
       expect(existing2.float_field).to eq(3.0)
     end
   end
+
+  context 'intercepting the matching record' do
+    it 'does not find the matching record and creates an object' do
+      existing = Account.create!(string_field: 'hook', integerField: 5)
+      
+      @query = %{
+        mutation {
+          createOrUpdateAccount(
+          where: { integerField: 5 }
+          data: {
+            floatField: 3.2,
+          }) {
+            id
+          }
+        }
+      }
+
+      subject
+      existing.reload
+      persisted = Account.find(subject['id'])
+
+      expect(existing.float_field).to be_nil
+      expect(persisted.float_field).to eq(3.2)
+    end
+  end
 end


### PR DESCRIPTION
# Description ✍️

This PR replaces the usage of the `resolve_one` resolver by the `resolve_find_before_create_or_update` into the `createOrUpdate` mutation.


# Checks ☑️

- [x] replace `resolve_one` by `resolve_find_before_create_or_update` into the `createOrUpdate` mutation.

