### PR TITLE
DIGIT-3417 Fix obsolete Metrics/LineLength cop, renamed to Layout/LineLength

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 *.gem
+.claude/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 Metrics/MethodLength:
   Max: 40
-Metrics/LineLength:
+Layout/LineLength:
   Max: 150
 Metrics/BlockLength:
   Max: 40


### PR DESCRIPTION
# Description ✍️

Fix an obsolete RuboCop cop name that was renamed in recent RuboCop versions from `Metrics/LineLength` to `Layout/LineLength`. Also add `.claude/` to gitignore for Claude Code workflow files.

# Overview 🔍

Two minimal changes:
1. **RuboCop config update**: Changed `Metrics/LineLength:` to `Layout/LineLength:` in `.rubocop.yml`
2. **Gitignore update**: Added `.claude/` to `.gitignore` to exclude Claude Code workflow directory

# Checks ☑️

- [x] RuboCop config is syntactically valid
- [x] No functional code changes
- [x] Configuration files properly formatted

# Plane Ticket 🎫

[DIGIT-3417](https://plane.oxean.com.br/oxeanbits/browse/DIGIT-3417)
