### PR TITLE
Add strict paginated model data hook

### DIFF
--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -30,15 +30,12 @@ module Graphoid
         field :skip, GraphQL::Types::Int, null: true
         field :data, [grapho.type], null: true, extras: [:lookahead]
 
-        def data(lookahead:)
-          object ||= @object
-          # Mongoid::Criteria uses method_missing to send the method to the underlying Model
-          # Just implement def self.lookahead(object, lookahead) in your model to manage
-          # eager loading
-          obj = object.lookahead(object, lookahead) if object.respond_to? :lookahead
-          object = obj if obj
-          return object.eager_load if object.respond_to? :eager_load
-          object
+        define_method(:data) do |lookahead:|
+          if model.respond_to?(:graphoid_load_paginated_data)
+            model.graphoid_load_paginated_data(object, lookahead: lookahead)
+          else
+            object
+          end
         end
 
         def page_size

--- a/lib/graphoid/queries/pagination.rb
+++ b/lib/graphoid/queries/pagination.rb
@@ -8,6 +8,22 @@ module Graphoid
       models.each { |model| Graphoid::Queries::Pagination.build(model) }
     end
 
+    def self.prepare_paginated_scope(model, scope, lookahead)
+      return model.graphoid_prepare_paginated_scope(scope, lookahead: lookahead) if
+        model.respond_to?(:graphoid_prepare_paginated_scope)
+      return scope unless scope.respond_to?(:lookahead)
+
+      scope.lookahead(scope, lookahead) || scope
+    end
+
+    def self.load_paginated_data(model, scope, lookahead)
+      return model.graphoid_load_paginated_data(scope, lookahead: lookahead) if
+        model.respond_to?(:graphoid_load_paginated_data)
+      return scope.eager_load if scope.respond_to?(:eager_load)
+
+      scope
+    end
+
     def self.build(model)
       Graphoid.initialize
       grapho = Graphoid.build(model)
@@ -31,11 +47,8 @@ module Graphoid
         field :data, [grapho.type], null: true, extras: [:lookahead]
 
         define_method(:data) do |lookahead:|
-          if model.respond_to?(:graphoid_load_paginated_data)
-            model.graphoid_load_paginated_data(object, lookahead: lookahead)
-          else
-            object
-          end
+          scope = Graphoid::Queries::Pagination.prepare_paginated_scope(model, object, lookahead)
+          Graphoid::Queries::Pagination.load_paginated_data(model, scope, lookahead)
         end
 
         def page_size

--- a/spec/tester_mongo/spec/graphoid/queries/pagination_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/queries/pagination_spec.rb
@@ -85,29 +85,37 @@ describe GraphqlController, type: :controller do
       end
     end
 
-    context 'with a paginated data model hook', limit: 2, skip_param: 0 do
+    context 'with paginated data model hooks', limit: 2, skip_param: 0 do
       let(:hook_arguments) { {} }
 
       before do
         arguments = hook_arguments
-        hook_result = [level2]
+        selected_name = level2.name
+        Level.define_singleton_method(:graphoid_prepare_paginated_scope) do |scope, lookahead:|
+          arguments[:prepare_scope] = scope
+          arguments[:prepare_lookahead] = lookahead
+          arguments[:prepared_scope] = scope.where(name: selected_name)
+        end
         Level.define_singleton_method(:graphoid_load_paginated_data) do |scope, lookahead:|
-          arguments[:scope] = scope
-          arguments[:lookahead] = lookahead
-          hook_result
+          arguments[:load_scope] = scope
+          arguments[:load_lookahead] = lookahead
+          scope.to_a
         end
 
         post :execute, params: { query: query }
       end
 
       after do
+        Level.singleton_class.remove_method(:graphoid_prepare_paginated_scope)
         Level.singleton_class.remove_method(:graphoid_load_paginated_data)
       end
 
-      it 'passes the resolved scope and lookahead directly to the model' do
-        expect(hook_arguments[:scope]).to be_a(Mongoid::Criteria)
-        expect(hook_arguments[:scope].options).to include(limit: 2, skip: 0)
-        selected_fields = hook_arguments[:lookahead].selections.map { |selection| selection.field.name }
+      it 'passes the resolved scope and lookahead through both model hooks' do
+        expect(hook_arguments[:prepare_scope]).to be_a(Mongoid::Criteria)
+        expect(hook_arguments[:prepare_scope].options).to include(limit: 2, skip: 0)
+        expect(hook_arguments[:load_scope]).to equal(hook_arguments[:prepared_scope])
+        expect(hook_arguments[:load_lookahead]).to equal(hook_arguments[:prepare_lookahead])
+        selected_fields = hook_arguments[:prepare_lookahead].selections.map { |selection| selection.field.name }
 
         expect(selected_fields).to contain_exactly('id', 'name', 'createdAt')
       end
@@ -124,21 +132,34 @@ describe GraphqlController, type: :controller do
     end
 
     context 'with legacy model loading methods', limit: 2, skip_param: 0 do
+      let(:legacy_calls) { [] }
+
       before do
-        Level.define_singleton_method(:lookahead) { |*, **| raise 'legacy lookahead called' }
-        Level.define_singleton_method(:eager_load) { |*, **| raise 'legacy eager_load called' }
+        calls = legacy_calls
+        hook_result = [level2]
+        Level.define_singleton_method(:lookahead) do |_scope, _lookahead|
+          calls << :lookahead
+          hook_result
+        end
 
         post :execute, params: { query: query }
       end
 
       after do
         Level.singleton_class.remove_method(:lookahead)
-        Level.singleton_class.remove_method(:eager_load)
       end
 
-      it 'does not dispatch pagination loading through criteria methods' do
+      it 'falls back to the legacy lookahead convention' do
         expect(response).to have_http_status(200)
         expect(JSON.parse(response.body)['errors']).to be_nil
+        expect(JSON.parse(response.body)['data']['levels']['data']).to contain_exactly(
+          {
+            'id' => level2.id.to_s,
+            'name' => level2.name,
+            'createdAt' => level2.created_at.iso8601(3)
+          }
+        )
+        expect(legacy_calls).to eq([:lookahead])
       end
     end
   end

--- a/spec/tester_mongo/spec/graphoid/queries/pagination_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/queries/pagination_spec.rb
@@ -84,5 +84,62 @@ describe GraphqlController, type: :controller do
         )
       end
     end
+
+    context 'with a paginated data model hook', limit: 2, skip_param: 0 do
+      let(:hook_arguments) { {} }
+
+      before do
+        arguments = hook_arguments
+        hook_result = [level2]
+        Level.define_singleton_method(:graphoid_load_paginated_data) do |scope, lookahead:|
+          arguments[:scope] = scope
+          arguments[:lookahead] = lookahead
+          hook_result
+        end
+
+        post :execute, params: { query: query }
+      end
+
+      after do
+        Level.singleton_class.remove_method(:graphoid_load_paginated_data)
+      end
+
+      it 'passes the resolved scope and lookahead directly to the model' do
+        expect(hook_arguments[:scope]).to be_a(Mongoid::Criteria)
+        expect(hook_arguments[:scope].options).to include(limit: 2, skip: 0)
+        selected_fields = hook_arguments[:lookahead].selections.map { |selection| selection.field.name }
+
+        expect(selected_fields).to contain_exactly('id', 'name', 'createdAt')
+      end
+
+      it 'uses the collection returned by the model hook' do
+        expect(JSON.parse(response.body)['data']['levels']['data']).to contain_exactly(
+          {
+            'id' => level2.id.to_s,
+            'name' => level2.name,
+            'createdAt' => level2.created_at.iso8601(3)
+          }
+        )
+      end
+    end
+
+    context 'with legacy model loading methods', limit: 2, skip_param: 0 do
+      before do
+        Level.define_singleton_method(:lookahead) { |*, **| raise 'legacy lookahead called' }
+        Level.define_singleton_method(:eager_load) { |*, **| raise 'legacy eager_load called' }
+
+        post :execute, params: { query: query }
+      end
+
+      after do
+        Level.singleton_class.remove_method(:lookahead)
+        Level.singleton_class.remove_method(:eager_load)
+      end
+
+      it 'does not dispatch pagination loading through criteria methods' do
+        expect(response).to have_http_status(200)
+        expect(JSON.parse(response.body)['errors']).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description ✍️

Adds two explicit model-class stages for generated pagination data:

```ruby
def self.graphoid_prepare_paginated_scope(scope, lookahead:)
  # Translate GraphQL selections into lazy scope changes.
end

def self.graphoid_load_paginated_data(scope, lookahead:)
  # Materialize or enrich the prepared collection when needed.
end
```

Graphoid previously called `lookahead` and `eager_load` only through the resolved query object. With Mongoid criteria, application hooks depended on `Criteria#method_missing`; Mongoid 9.1 adding `Criteria#eager_load` changed dispatch and bypassed the model loader.

The new stages call the captured model directly while retaining the former query-object methods as fallbacks for models that have not migrated.

# Overview 🔍

```mermaid
flowchart LR
  A[Resolved pagination scope] --> B{Prepare model hook?}
  B -->|Yes| C[Prepare scope directly]
  B -->|No| D[Legacy scope.lookahead fallback]
  C --> E{Load model hook?}
  D --> E
  E -->|Yes| F[Load data directly]
  E -->|No| G[Legacy scope.eager_load fallback]
  F --> H[GraphQL serialization]
  G --> H
```

## Responsibilities

| Stage | Responsibility | Expected database behavior |
|---|---|---|
| `graphoid_prepare_paginated_scope` | Convert lookahead selections into scope instructions | Remains lazy |
| `graphoid_load_paginated_data` | Perform custom materialization or batching | May execute queries |
| Legacy `lookahead` fallback | Preserve the previous preparation convention | Consumer-defined |
| Legacy `eager_load` fallback | Preserve native/previous eager loading | Query-object-defined |

- Passes the fully resolved filter/order/limit/skip scope into preparation.
- Passes the exact prepared scope into loading.
- Passes GraphQL `data` lookahead as a required keyword to direct hooks.
- Gives direct model hooks precedence over legacy query-object methods.
- Preserves the old positional `scope.lookahead(scope, lookahead)` contract as fallback.
- Preserves nil-result behavior for legacy lookahead by retaining the incoming scope.
- Supports criteria or materialized collection return values.

# Checks ☑️

- [x] Primary Mongo tester: 88 examples, 0 failures, 7 existing pending
- [x] Alternate GraphQL tester: 88 examples, 0 failures, 7 existing pending
- [x] Focused pagination coverage: 7 examples, 0 failures in both tester bundles
- [x] Direct prepare/load sequencing covered
- [x] Legacy lookahead fallback covered
- [x] `git diff --check`

## Test Guidance

1. Run `ASDF_RUBY_VERSION=3.4.8 DRIVER=mongo bundle exec rspec spec/graphoid/queries/pagination_spec.rb` from `spec/tester_mongo`.
2. Repeat from `spec/tester_mongo_rails_6` for the alternate GraphQL dependency.
3. Define both direct hooks and confirm the loader receives the exact criteria returned by preparation.
4. Return a materialized collection from the loader and confirm GraphQL serializes it.
5. Remove the direct hooks, define legacy `lookahead`, and confirm fallback behavior remains available.
6. Query a model without custom hooks and confirm normal filtering, ordering, limit, and skip behavior remains unchanged.
