### PR TITLE
Correlate relation filters with parent scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ API by select the models to generate Types, Queries and Mutations.
 Rails.application.config.after_initialize do
   Graphoid.configure do |config|
     config.driver = :mongoid
+    config.relation_filter_max_keys = 10_000
   end
 
   Graphoid.initialize
@@ -41,6 +42,15 @@ Rails.application.config.after_initialize do
   Graphoid::Queries.generate(User, Contract)
   Graphoid::Mutations.generate(User, Contract)
 end
+```
+
+Referenced relation filters are correlated with the current parent scope before the related model is queried. `relation_filter_max_keys` bounds the distinct association keys carried between the correlated queries so unexpectedly broad filters fail instead of exhausting application memory or creating oversized MongoDB selectors.
+
+Applications can authorize each referenced target scope with an explicit execution context. Scope providers receive the target model, Mongoid association metadata, and the already-scoped parent criteria:
+
+```ruby
+context = Graphoid::Queries::ExecutionContext.new(scope_provider)
+Graphoid::Queries::Processor.execute(records, filters, context: context)
 ```
 
 ## Examples
@@ -56,7 +66,7 @@ In this same repository.
 - Aggregations
 - Permissions on fields
 - Relation with aliases tests
-- Write division for "every" in Mongoid and AR
+- Write division for "every" in Active Record
 - Sort top level models by association values
 - Filter by Array or Hash.
 - has_one_through implementation

--- a/lib/graphoid/config.rb
+++ b/lib/graphoid/config.rb
@@ -33,9 +33,18 @@ module Graphoid
 
   class Configuration
     attr_accessor :driver
+    attr_reader :relation_filter_max_keys
 
     def initialize
       @driver = :mongoid
+      @relation_filter_max_keys = 10_000
+    end
+
+    def relation_filter_max_keys=(value)
+      max_keys = Integer(value)
+      raise ArgumentError, 'relation_filter_max_keys must be positive' unless max_keys.positive?
+
+      @relation_filter_max_keys = max_keys
     end
   end
 end

--- a/lib/graphoid/drivers/mongoid_driver.rb
+++ b/lib/graphoid/drivers/mongoid_driver.rb
@@ -155,9 +155,11 @@ module Graphoid
         scope.and(parsed)
       end
 
-      def execute_or(scope, list)
+      def execute_or(scope, list, context: nil)
+        context ||= Graphoid::Queries::ExecutionContext.new
+
         list.map! do |object|
-          Graphoid::Queries::Processor.execute(scope, object).selector
+          Graphoid::Queries::Processor.execute(scope, object, context: context).selector
         end
         scope.any_of(list)
       end
@@ -185,14 +187,14 @@ module Graphoid
         parsed
       end
 
-      def relate_embedded(scope, relation, filters)
+      def relate_embedded(scope, relation, filters, context: nil)
         # TODO: this way of fetching this is not recursive as the regular fields
         # because the structure of the query is embeeded.field = value
         # we need more brain cells on this problem because it does not allow
         # to filter things using OR/AND
         parsed = {}
         filters.each do |key, value|
-          operation = Operation.new(scope, key, value)
+          operation = Operation.new(scope, key, value, context: context)
           attribute = OpenStruct.new(name: "#{relation.name}.#{operation.operand}")
           obj = parse(attribute, value, operation.operator).first
           parsed[obj[0]] = obj[1]
@@ -200,45 +202,95 @@ module Graphoid
         parsed
       end
 
-      def relate_one(scope, relation, value)
-        field = relation.name
-        parsed = {}
+      def relate_one(scope, relation, value, context: nil)
+        return relate_embedded(scope, relation, value, context: context) if relation.embeds_one?
 
-        parsed = relate_embedded(scope, relation, value) if relation.embeds_one?
-
-        parsed = relation.exec(scope, value) if relation.belongs_to?
-
-        parsed = relation.exec(scope, value) if relation.has_one?
-
-        parsed
+        correlate_referenced_relation(scope, relation, value, 'some', context: context)
       end
 
-      def relate_many(scope, relation, value, operator)
-        field_name = relation.inverse_name || scope.name.underscore
-        target = Graphoid::Queries::Processor.execute(relation.klass, value).to_a
+      def relate_many(scope, relation, value, operator, context: nil)
+        return {} if relation.embeds_many?
+        return correlate_every_relation(scope, relation, value, context: context) if operator == 'every'
 
-        if relation.embeds_many?
-          # TODO: not implemented at all.
-        end
+        correlate_referenced_relation(scope, relation, value, operator, context: context)
+      end
 
-        if relation.many_to_many?
-          field_name = field_name.to_s.singularize + '_ids'
-          ids = target.map(&field_name.to_sym)
-          ids.flatten!.uniq!
+      def correlate_referenced_relation(scope, relation, filters, operator, context: nil)
+        parent_key, target_key = correlation_keys(relation)
+        reachable_keys = project_distinct_keys(scope, parent_key)
+        target_scope = correlated_target_scope(scope, relation, target_key, reachable_keys, context)
+        matching_keys = matching_relation_keys(target_scope, target_key, filters, context)
+        comparison = operator == 'none' ? 'nin' : 'in'
+
+        parse(Attribute.new(name: parent_key, type: nil), matching_keys, comparison)
+      end
+
+      def correlate_every_relation(scope, relation, filters, context: nil)
+        parent_key, target_key = correlation_keys(relation)
+        reachable_keys = project_distinct_keys(scope, parent_key)
+        target_scope = correlated_target_scope(scope, relation, target_key, reachable_keys, context)
+        violating_keys = violating_relation_keys(target_scope, target_key, filters, context)
+
+        parse(Attribute.new(name: parent_key, type: nil), violating_keys, 'nin')
+      end
+
+      def correlation_keys(relation)
+        if relation.belongs_to? || relation.many_to_many?
+          [relation.foreign_key, relation.primary_key]
         else
-          field_name = field_name.to_s + '_id'
-          ids = target.map(&field_name.to_sym)
+          [relation.primary_key, relation.foreign_key]
         end
+      end
 
-        parsed = {}
-        if operator == 'none'
-          parsed[:id.nin] = ids
-        elsif operator == 'some'
-          parsed[:id.in] = ids
-        elsif operator == 'every'
-          # missing implementation
-        end
-        parsed
+      def correlated_target_scope(parent_scope, relation, target_key, reachable_keys, context)
+        return nil if reachable_keys.empty?
+
+        correlation = parse(Attribute.new(name: target_key, type: nil), reachable_keys, 'in')
+        authorized_scope = context.scope_for(
+          relation.klass,
+          relation: relation.metadata,
+          parent_scope: parent_scope
+        )
+        execute_and(authorized_scope, correlation)
+      end
+
+      def matching_relation_keys(target_scope, target_key, filters, context)
+        return [] unless target_scope
+
+        matching_scope = Graphoid::Queries::Processor.execute(target_scope, filters, context: context)
+        project_distinct_keys(matching_scope, target_key)
+      end
+
+      def violating_relation_keys(target_scope, target_key, filters, context)
+        return [] unless target_scope
+
+        matching_scope = Graphoid::Queries::Processor.execute(target_scope, filters, context: context)
+        violating_scope = target_scope.and('$nor' => [matching_scope.selector])
+        project_distinct_keys(violating_scope, target_key)
+      end
+
+      def project_distinct_keys(scope, field)
+        criteria = scope.respond_to?(:selector) ? scope : scope.all
+        storage_field = criteria.klass.database_field_name(field.to_s)
+        max_keys = Graphoid.configuration.relation_filter_max_keys
+        pipeline = projection_pipeline(criteria, storage_field, max_keys)
+        keys = criteria.collection.aggregate(pipeline).map { |document| document['_id'] }
+
+        return keys if keys.length <= max_keys
+
+        raise RelationFilterCardinalityError,
+              "Relation filter exceeded #{max_keys} distinct keys for #{criteria.klass.name}.#{field}"
+      end
+
+      def projection_pipeline(criteria, storage_field, max_keys)
+        pipeline = []
+        pipeline << { '$match' => criteria.selector } unless criteria.selector.empty?
+        pipeline << { '$project' => { '__graphoid_key' => "$#{storage_field}" } }
+        pipeline << { '$unwind' => '$__graphoid_key' }
+        pipeline << { '$match' => { '__graphoid_key' => { '$ne' => nil } } }
+        pipeline << { '$group' => { '_id' => '$__graphoid_key' } }
+        pipeline << { '$limit' => max_keys + 1 }
+        pipeline
       end
     end
   end

--- a/lib/graphoid/graphoid.rb
+++ b/lib/graphoid/graphoid.rb
@@ -19,6 +19,8 @@ require 'graphoid/operators/inherited/many_to_many'
 
 require 'graphoid/queries/queries'
 require 'graphoid/queries/pagination'
+require 'graphoid/queries/execution_context'
+require 'graphoid/queries/relation_filter_cardinality_error'
 require 'graphoid/queries/processor'
 require 'graphoid/queries/operation'
 

--- a/lib/graphoid/operators/inherited/belongs_to.rb
+++ b/lib/graphoid/operators/inherited/belongs_to.rb
@@ -7,11 +7,5 @@ module Graphoid
       foreign_id = klass.create!(sanitized).id
       { :"#{name}_id" => foreign_id }
     end
-
-    def exec(_, value)
-      ids = Graphoid::Queries::Processor.execute(klass, value).to_a.map(&:id)
-      attribute = Attribute.new(name: "#{name.underscore}_id", type: nil)
-      Graphoid.driver.parse(attribute, ids, 'in')
-    end
   end
 end

--- a/lib/graphoid/operators/inherited/embeds_many.rb
+++ b/lib/graphoid/operators/inherited/embeds_many.rb
@@ -9,11 +9,11 @@ module Graphoid
       end
     end
 
-    def exec(_scope, value)
+    def exec(_scope, value, context: nil)
       _hash = {}
 
       value.each do |key, _value|
-        operation = Operation.new(klass, key, _value)
+        operation = Operation.new(klass, key, _value, context: context)
         parsed = Graphoid.driver.parse(operation.operand, operation.value, operation.operator, klass.to_s.underscore.pluralize)
         _hash.merge!(parsed)
       end

--- a/lib/graphoid/operators/inherited/embeds_one.rb
+++ b/lib/graphoid/operators/inherited/embeds_one.rb
@@ -7,11 +7,11 @@ module Graphoid
       parent.send(:"#{name}=", attrs)
     end
 
-    def exec(_scope, value)
+    def exec(_scope, value, context: nil)
       _hash = {}
 
       value.each do |key, _value|
-        operation = Operation.new(klass, key, _value)
+        operation = Operation.new(klass, key, _value, context: context)
         parsed = Graphoid.driver.parse(operation.operand, operation.value, operation.operator, klass.to_s.underscore)
         _hash.merge!(parsed)
       end

--- a/lib/graphoid/operators/inherited/has_one.rb
+++ b/lib/graphoid/operators/inherited/has_one.rb
@@ -7,12 +7,5 @@ module Graphoid
       attributes[:"#{grapho.name}_id"] = parent.id
       klass.create!(attributes)
     end
-
-    def exec(scope, value)
-      field_name = inverse_name || scope.name.underscore
-      ids = Graphoid::Queries::Processor.execute(klass, value).to_a.map(&"#{field_name}_id".to_sym)
-      attribute = Attribute.new(name: 'id', type: nil)
-      Graphoid.driver.parse(attribute, ids, 'in')
-    end
   end
 end

--- a/lib/graphoid/operators/relation.rb
+++ b/lib/graphoid/operators/relation.rb
@@ -2,14 +2,23 @@
 
 module Graphoid
   class Relation
-    attr_reader :name, :klass, :type, :inverse_name
+    attr_reader :name, :klass, :type, :inverse_name, :metadata
 
     def initialize(relation)
+      @metadata = relation
       @name = relation.name.to_s
       @camel_name = Utils.camelize(@name)
       @inverse_name = Graphoid.driver.inverse_name_of(relation)
       @klass = relation.class_name.constantize
       @type = Graphoid.driver.relation_type(relation)
+    end
+
+    def foreign_key
+      metadata.foreign_key.to_s
+    end
+
+    def primary_key
+      metadata.primary_key.to_s
     end
 
     %i[has_and_belongs_to_many through has_many belongs_to has_one embeds_one embeds_many embedded_in].each do |type|
@@ -49,12 +58,27 @@ module Graphoid
     def create(_, _, _); end
 
     def resolve(operation)
-      if one? || operation.operand.embedded?
-        return operation.operand.exec(operation.scope, operation.value)
+      if operation.operand.embedded?
+        return operation.operand.exec(operation.scope, operation.value, context: operation.context)
+      end
+
+      if one?
+        return Graphoid.driver.relate_one(
+          operation.scope,
+          operation.operand,
+          operation.value,
+          context: operation.context
+        )
       end
 
       if many?
-        return Graphoid.driver.relate_many(operation.scope, operation.operand, operation.value, operation.operator)
+        return Graphoid.driver.relate_many(
+          operation.scope,
+          operation.operand,
+          operation.value,
+          operation.operator,
+          context: operation.context
+        )
       end
     end
 

--- a/lib/graphoid/queries/execution_context.rb
+++ b/lib/graphoid/queries/execution_context.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Graphoid
+  module Queries
+    class ExecutionContext
+      def initialize(scope_provider = nil, &scope_provider_block)
+        @scope_provider = scope_provider || scope_provider_block
+      end
+
+      def scope_for(model, relation:, parent_scope:)
+        return model.all unless @scope_provider
+
+        if @scope_provider.respond_to?(:scope_for)
+          return @scope_provider.scope_for(model, relation: relation, parent_scope: parent_scope)
+        end
+
+        @scope_provider.call(model, relation: relation, parent_scope: parent_scope)
+      end
+    end
+  end
+end

--- a/lib/graphoid/queries/operation.rb
+++ b/lib/graphoid/queries/operation.rb
@@ -2,15 +2,16 @@
 
 module Graphoid
   class Operation
-    attr_reader :scope, :operand, :operator, :value
+    attr_reader :scope, :operand, :operator, :value, :context
 
     OPERATORS_REGEX = /^(.+)_(lt|lte|gt|gte|contains|not|in|nin|regex|some|none|every)$/.freeze
 
-    def initialize(scope, key, value, camelize: false)
+    def initialize(scope, key, value, camelize: false, context: nil)
       # camelize it because graphql 2.0 is passing keys as symbols using underscore format
       # but for queries we need the underscore format to identify operators such as contains, regex
       key = key.to_s.camelcase(:lower) if camelize
       @scope = scope
+      @context = context || Graphoid::Queries::ExecutionContext.new
       @operator = nil
       @operand = key
       @value = value
@@ -56,4 +57,3 @@ module Graphoid
     end
   end
 end
-

--- a/lib/graphoid/queries/processor.rb
+++ b/lib/graphoid/queries/processor.rb
@@ -4,34 +4,41 @@ module Graphoid
   module Queries
     module Processor
       class << self
-        def execute(scope, object)
+        def execute(scope, object = nil, context: nil, **object_keywords)
+          context ||= ExecutionContext.new
+          object ||= object_keywords
+
           object.each do |key, value|
             key = key.to_s if key.is_a? Symbol
-            scope = process(scope, value, key)
+            scope = process(scope, value, key, context: context)
           end
           scope
         end
 
-        def execute_array(scope, list, action)
+        def execute_array(scope, list, action, context: nil)
+          context ||= ExecutionContext.new
+
           if action == 'OR'
-            scope = Graphoid.driver.execute_or(scope, list)
+            scope = Graphoid.driver.execute_or(scope, list, context: context)
           else
-            list.each { |object| scope = execute(scope, object) }
+            list.each { |object| scope = execute(scope, object, context: context) }
           end
           scope
         end
 
-        def process(scope, value, key = nil)
+        def process(scope, value, key = nil, context: nil)
+          context ||= ExecutionContext.new
+
           if key && %w[OR AND].exclude?(key)
-            operation = Operation.new(scope, key, value)
+            operation = Operation.new(scope, key, value, context: context)
             filter = operation.resolve
             return Graphoid.driver.execute_and(scope, filter)
           end
 
           if operation.nil? || operation.type == :attribute
-            return execute(scope, value) if value.is_a?(Hash)
+            return execute(scope, value, context: context) if value.is_a?(Hash)
             if value.is_a?(Array) && %w[in nin].exclude?(operation&.operator)
-              return execute_array(scope, value, key)
+              return execute_array(scope, value, key, context: context)
             end
           end
         end
@@ -44,4 +51,3 @@ module Graphoid
     end
   end
 end
-

--- a/lib/graphoid/queries/relation_filter_cardinality_error.rb
+++ b/lib/graphoid/queries/relation_filter_cardinality_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Graphoid
+  class RelationFilterCardinalityError < StandardError; end
+end

--- a/spec/tester_mongo/app/models/correlated_relation_child.rb
+++ b/spec/tester_mongo/app/models/correlated_relation_child.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CorrelatedRelationChild
+  include Mongoid::Document
+
+  field :parent_lookup, type: String
+  field :reviewer_code, type: String
+  field :tenant, type: String
+  field :status, type: String
+
+  belongs_to :reviewer,
+             class_name: 'CorrelatedRelationOwner',
+             foreign_key: 'reviewer_code',
+             primary_key: 'code',
+             optional: true
+end

--- a/spec/tester_mongo/app/models/correlated_relation_owner.rb
+++ b/spec/tester_mongo/app/models/correlated_relation_owner.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CorrelatedRelationOwner
+  include Mongoid::Document
+
+  field :code, type: String
+  field :tenant, type: String
+  field :name, type: String
+end

--- a/spec/tester_mongo/app/models/correlated_relation_parent.rb
+++ b/spec/tester_mongo/app/models/correlated_relation_parent.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CorrelatedRelationParent
+  include Mongoid::Document
+
+  field :lookup, type: String
+  field :owner_code, type: String
+  field :tenant, type: String
+  field :name, type: String
+
+  belongs_to :owner,
+             class_name: 'CorrelatedRelationOwner',
+             foreign_key: 'owner_code',
+             primary_key: 'code',
+             optional: true
+
+  has_one :profile,
+          class_name: 'CorrelatedRelationProfile',
+          foreign_key: 'parent_lookup',
+          primary_key: 'lookup'
+
+  has_many :children,
+           class_name: 'CorrelatedRelationChild',
+           foreign_key: 'parent_lookup',
+           primary_key: 'lookup'
+end

--- a/spec/tester_mongo/app/models/correlated_relation_profile.rb
+++ b/spec/tester_mongo/app/models/correlated_relation_profile.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CorrelatedRelationProfile
+  include Mongoid::Document
+
+  field :parent_lookup, type: String
+  field :tenant, type: String
+  field :status, type: String
+end

--- a/spec/tester_mongo/spec/graphoid/queries/relations/correlated_relations_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/queries/relations/correlated_relations_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'when filtering referenced relations from a scoped parent criteria' do
+  before do
+    CorrelatedRelationParent.delete_all
+    CorrelatedRelationOwner.delete_all
+    CorrelatedRelationProfile.delete_all
+    CorrelatedRelationChild.delete_all
+
+    @alpha_matching_owner = CorrelatedRelationOwner.create!(code: 'owner-alpha-match', tenant: 'alpha', name: 'matching')
+    @alpha_other_owner = CorrelatedRelationOwner.create!(code: 'owner-alpha-other', tenant: 'alpha', name: 'other')
+    @beta_matching_owner = CorrelatedRelationOwner.create!(code: 'owner-beta-match', tenant: 'beta', name: 'matching')
+
+    @alpha_matching_parent = CorrelatedRelationParent.create!(
+      lookup: 'parent-alpha-match', owner_code: @alpha_matching_owner.code, tenant: 'alpha', name: 'relation match'
+    )
+    @alpha_other_parent = CorrelatedRelationParent.create!(
+      lookup: 'parent-alpha-other', owner_code: @alpha_other_owner.code, tenant: 'alpha', name: 'fallback'
+    )
+    @beta_matching_parent = CorrelatedRelationParent.create!(
+      lookup: 'parent-beta-match', owner_code: @beta_matching_owner.code, tenant: 'beta', name: 'relation match'
+    )
+
+    CorrelatedRelationProfile.create!(parent_lookup: @alpha_matching_parent.lookup, tenant: 'alpha', status: 'active')
+    CorrelatedRelationProfile.create!(parent_lookup: @alpha_other_parent.lookup, tenant: 'alpha', status: 'inactive')
+    CorrelatedRelationProfile.create!(parent_lookup: @beta_matching_parent.lookup, tenant: 'beta', status: 'active')
+
+    CorrelatedRelationChild.create!(
+      parent_lookup: @alpha_matching_parent.lookup,
+      reviewer_code: @alpha_matching_owner.code,
+      tenant: 'alpha',
+      status: 'active'
+    )
+    CorrelatedRelationChild.create!(
+      parent_lookup: @alpha_other_parent.lookup,
+      reviewer_code: @alpha_other_owner.code,
+      tenant: 'alpha',
+      status: 'inactive'
+    )
+    CorrelatedRelationChild.create!(
+      parent_lookup: @beta_matching_parent.lookup,
+      reviewer_code: @beta_matching_owner.code,
+      tenant: 'beta',
+      status: 'active'
+    )
+
+    @alpha_scope = CorrelatedRelationParent.where(tenant: 'alpha')
+  end
+
+  it 'should correlate belongs_to filters through custom foreign and primary keys' do
+    result = Graphoid::Queries::Processor.execute(@alpha_scope, owner: { name: 'matching' })
+
+    expect(result.pluck(:id)).to eq([@alpha_matching_parent.id])
+  end
+
+  it 'should correlate has_one filters through custom foreign and primary keys' do
+    result = Graphoid::Queries::Processor.execute(@alpha_scope, profile: { status: 'active' })
+
+    expect(result.pluck(:id)).to eq([@alpha_matching_parent.id])
+  end
+
+  it 'should preserve has_many some and none semantics inside the parent scope' do
+    some = Graphoid::Queries::Processor.execute(@alpha_scope, children_some: { status: 'active' })
+    none = Graphoid::Queries::Processor.execute(@alpha_scope, children_none: { status: 'active' })
+
+    expect(some.pluck(:id)).to eq([@alpha_matching_parent.id])
+    expect(none.pluck(:id)).to eq([@alpha_other_parent.id])
+  end
+
+  it 'should preserve the correlated scope through recursive and boolean filters' do
+    filters = {
+      'OR' => [
+        { 'children_some' => { 'reviewer' => { 'name' => 'matching' } } },
+        { 'name' => 'fallback' }
+      ]
+    }
+
+    result = Graphoid::Queries::Processor.execute(@alpha_scope, filters)
+
+    expect(result.pluck(:id)).to contain_exactly(@alpha_matching_parent.id, @alpha_other_parent.id)
+  end
+
+  it 'should authorize every recursively correlated target through the execution context' do
+    provider = CorrelatedRelationScopeProvider.new(@alpha_matching_owner.code)
+    context = Graphoid::Queries::ExecutionContext.new(provider)
+    filters = {
+      'AND' => [
+        {
+          'OR' => [
+            { 'children_some' => { 'reviewer' => { 'name' => 'matching' } } },
+            { 'name' => 'missing' }
+          ]
+        }
+      ]
+    }
+
+    result = Graphoid::Queries::Processor.execute(@alpha_scope, filters, context: context)
+
+    expect(result).to be_empty
+    expect(provider.relations).to include(:children, :reviewer)
+  end
+
+  it 'should apply every to all authorized correlated children with vacuous truth' do
+    empty_parent = CorrelatedRelationParent.create!(
+      lookup: 'parent-alpha-empty',
+      owner_code: @alpha_other_owner.code,
+      tenant: 'alpha',
+      name: 'empty'
+    )
+
+    result = Graphoid::Queries::Processor.execute(@alpha_scope, children_every: { status: 'active' })
+
+    expect(result.pluck(:id)).to contain_exactly(@alpha_matching_parent.id, empty_parent.id)
+  end
+
+  it 'should leave ordering and pagination on the returned criteria after relation filtering' do
+    paginated_scope = @alpha_scope.order(name: :asc).limit(1)
+
+    result = Graphoid::Queries::Processor.execute(paginated_scope, owner: { name: 'matching' })
+
+    expect(result).to be_a(Mongoid::Criteria)
+    expect(result.pluck(:id)).to eq([@alpha_matching_parent.id])
+  end
+
+  it 'should use key-only aggregations and restrict target candidates to reachable parent keys' do
+    subscriber = RelationCommandSubscriber.new
+    client = Mongoid.default_client
+    client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+
+    Graphoid::Queries::Processor.execute(@alpha_scope, owner: { name: 'matching' }).to_a
+
+    owner_aggregates = subscriber.started_events.select do |event|
+      event.command_name.to_s == 'aggregate' &&
+        event.command['aggregate'] == CorrelatedRelationOwner.collection_name.to_s
+    end
+    owner_finds = subscriber.started_events.select do |event|
+      event.command_name.to_s == 'find' &&
+        event.command['find'] == CorrelatedRelationOwner.collection_name.to_s
+    end
+
+    expect(owner_finds).to be_empty
+    expect(owner_aggregates.length).to eq(1)
+
+    pipeline = owner_aggregates.first.command['pipeline']
+    expect(pipeline).to include('$project' => { '__graphoid_key' => '$code' })
+    expect(pipeline).to include('$group' => { '_id' => '$__graphoid_key' })
+    reachable_owner_codes = pipeline.first.fetch('$match').fetch('code').fetch('$in')
+    expect(reachable_owner_codes).to contain_exactly(@alpha_matching_owner.code, @alpha_other_owner.code)
+    expect(reachable_owner_codes).not_to include(@beta_matching_owner.code)
+  ensure
+    client&.unsubscribe(Mongo::Monitoring::COMMAND, subscriber)
+  end
+
+  it 'should fail deterministically before querying targets when reachable key cardinality exceeds the limit' do
+    previous_limit = Graphoid.configuration.relation_filter_max_keys
+    Graphoid.configuration.relation_filter_max_keys = 1
+
+    expect do
+      Graphoid::Queries::Processor.execute(@alpha_scope, owner: { name: 'matching' })
+    end.to raise_error(
+      Graphoid::RelationFilterCardinalityError,
+      'Relation filter exceeded 1 distinct keys for CorrelatedRelationParent.owner_code'
+    )
+  ensure
+    Graphoid.configuration.relation_filter_max_keys = previous_limit
+  end
+end
+
+class RelationCommandSubscriber
+  attr_reader :started_events
+
+  def initialize
+    @started_events = []
+  end
+
+  def started(event)
+    started_events << event
+  end
+
+  def succeeded(_event); end
+
+  def failed(_event); end
+end
+
+class CorrelatedRelationScopeProvider
+  attr_reader :relations
+
+  def initialize(excluded_owner_code)
+    @excluded_owner_code = excluded_owner_code
+    @relations = []
+  end
+
+  def scope_for(model, relation:, parent_scope:)
+    relations << relation.name
+    return model.all unless model == CorrelatedRelationOwner
+
+    model.where(:code.nin => [@excluded_owner_code])
+  end
+end

--- a/spec/tester_mongo/spec/graphoid/queries/relations/has_many_spec.rb
+++ b/spec/tester_mongo/spec/graphoid/queries/relations/has_many_spec.rb
@@ -73,12 +73,6 @@ describe 'QueryHasMany', type: :request do
         }
       }
 
-      if ENV['DRIVER'] == 'mongo'
-        # TODO: build the _every division for mongoid
-        pending
-        raise
-      end
-
       expect(subject.size).to eq(2)
       expect(subject[0]['id']).to eq a0.id.to_s
       expect(subject[0]['labels'][0]['id']).to eq l0.id.to_s


### PR DESCRIPTION
# Description ✍️

Correlate Mongoid relation filters with the already-scoped parent criteria instead of querying and hydrating the related collection globally.

This prevents nested filters such as `record: { sheet: { id_not: null } }` from inspecting unrelated projects and bounds the association keys carried between MongoDB queries.

# Overview 🔍

- Project distinct association keys from the current parent scope with key-only aggregation pipelines.
- Restrict target criteria through Mongoid association metadata before applying nested predicates.
- Propagate an optional `ExecutionContext` scope provider through recursive, `AND`, and `OR` filters.
- Preserve `Processor.execute(scope, filters)` compatibility and the `Mongoid::Criteria` result path.
- Support custom foreign/primary keys and `belongs_to`, `has_one`, `has_many_some`, `has_many_none`, and `has_many_every` semantics.
- Raise `RelationFilterCardinalityError` when a relation exceeds the configured key bound instead of constructing an unbounded `$in` selector.

```ruby
context = Graphoid::Queries::ExecutionContext.new(scope_provider)
Graphoid::Queries::Processor.execute(records, filters, context: context)
```

# Checks ☑️

- [x] Full Mongoid tester suite passes: 94 examples, 0 failures, 6 pre-existing pending
- [x] Parent and target operations use key-only aggregations
- [x] Cross-scope target keys are excluded
- [x] Recursive and boolean relation filters retain execution context
- [x] Custom association keys are covered
- [x] Ruby 2.7 syntax compatibility checked

# Test Guidance

1. Start MongoDB on `localhost:27017`.
2. Run `DRIVER=mongo bundle exec rspec` from `spec/tester_mongo`.
3. Confirm all 94 examples pass and only the six documented pending examples remain.
4. Run `spec/graphoid/queries/relations/correlated_relations_spec.rb` independently.
5. Confirm the command-monitoring example observes target `aggregate` operations with `$project`/`$group`, no target `find`, and no keys from the foreign parent scope.
6. Set `relation_filter_max_keys` below the fixture cardinality and confirm the query raises `Graphoid::RelationFilterCardinalityError` before querying targets.
